### PR TITLE
[FE] 바뀐 룰렛 방식에 맞게 코드 리팩터링

### DIFF
--- a/fe/src/components/GameBoard/Roulette.tsx
+++ b/fe/src/components/GameBoard/Roulette.tsx
@@ -3,7 +3,7 @@ import useGetSocketUrl from '@hooks/useGetSocketUrl';
 import useSound from '@hooks/useSound';
 import { usePlayerIdValue } from '@store/index';
 import {
-  useGameInfo,
+  useGameInfoValue,
   useResetEventRound,
   useRouletteTimer,
 } from '@store/reducer';
@@ -21,7 +21,7 @@ export default function Roulette() {
 
   const [rouletteTimer, setRouletteTimer] = useRouletteTimer();
   const { gameId } = useParams();
-  const [gameInfo] = useGameInfo();
+  const { eventList, eventResult, firstPlayerId } = useGameInfoValue();
   const playerId = usePlayerIdValue();
   const socketUrl = useGetSocketUrl();
   const resetGameInfo = useResetEventRound();
@@ -35,23 +35,17 @@ export default function Roulette() {
   });
 
   const startSpin = useCallback(() => {
-    const eventListData = gameInfo.eventList.map((event) => event.title);
-    if (eventListData.length === 0) return;
-    if (gameInfo.firstPlayerId !== playerId) return;
+    const eventTitles = eventList.map((event) => event.title);
+    if (eventTitles.length === 0) return;
+    if (firstPlayerId !== playerId) return;
     const message = {
       type: 'eventResult',
       gameId,
-      events: eventListData,
+      events: eventTitles,
     };
     sendJsonMessage(message);
     setIsRolling(true);
-  }, [
-    gameId,
-    playerId,
-    gameInfo.eventList,
-    gameInfo.firstPlayerId,
-    sendJsonMessage,
-  ]);
+  }, [gameId, playerId, eventList, firstPlayerId, sendJsonMessage]);
 
   useEffect(() => {
     let isMounted = true;
@@ -76,16 +70,16 @@ export default function Roulette() {
   }, [rouletteTimer, setRouletteTimer, startSpin]);
 
   useEffect(() => {
-    if (gameInfo.eventResult === '') return;
-    const prizeNumber = gameInfo.eventList.findIndex(
-      (event) => event.title === gameInfo.eventResult
+    if (eventResult === '') return;
+    const prizeNumber = eventList.findIndex(
+      (event) => event.title === eventResult
     );
     setPrizeNumber(prizeNumber);
     setMustSpin(true);
-  }, [gameInfo.eventResult, gameInfo.eventList]);
+  }, [eventResult, eventList]);
 
-  if (gameInfo.eventList.length === 0) return null;
-  const wheelData = gameInfo.eventList.map((event) => {
+  if (eventList.length === 0) return null;
+  const wheelData = eventList.map((event) => {
     return { option: event.title };
   });
 

--- a/fe/src/components/GameBoard/Roulette.tsx
+++ b/fe/src/components/GameBoard/Roulette.tsx
@@ -33,7 +33,7 @@ export default function Roulette() {
         alert('이벤트 룰렛을 정상적으로 불러오지 못했습니다.');
         return;
       }
-      if (rouletteTimer >= 0 && !isRolling) {
+      if (rouletteTimer > 0 && !isRolling) {
         setRouletteTimer((prev) => prev - 1);
       }
     };

--- a/fe/src/components/GameBoard/Roulette.tsx
+++ b/fe/src/components/GameBoard/Roulette.tsx
@@ -2,7 +2,11 @@ import EventModal from '@components/Modal/EventModal/EventModal';
 import useGetSocketUrl from '@hooks/useGetSocketUrl';
 import useSound from '@hooks/useSound';
 import { usePlayerIdValue } from '@store/index';
-import { useGameInfo, useResetEventRound } from '@store/reducer';
+import {
+  useGameInfo,
+  useResetEventRound,
+  useRouletteTimer,
+} from '@store/reducer';
 import { delay } from '@utils/index';
 import { useCallback, useEffect, useState } from 'react';
 import { Wheel } from 'react-custom-roulette';
@@ -13,9 +17,9 @@ import { styled } from 'styled-components';
 export default function Roulette() {
   const [mustSpin, setMustSpin] = useState(false);
   const [prizeNumber, setPrizeNumber] = useState(0);
-  const [stockSellTime, setStockSellTime] = useState(15);
   const [isEventModalOpen, setIsEventModalOpen] = useState(false);
 
+  const [rouletteTimer, setRouletteTimer] = useRouletteTimer();
   const { gameId } = useParams();
   const [gameInfo] = useGameInfo();
   const playerId = usePlayerIdValue();
@@ -54,8 +58,12 @@ export default function Roulette() {
     const stockSellTimer = async () => {
       await delay(1000);
       if (!isMounted) return;
-      if (stockSellTime > 0) {
-        setStockSellTime((prev) => prev - 1);
+      if (rouletteTimer === undefined) {
+        alert('이벤트 룰렛을 정상적으로 불러오지 못했습니다.');
+        return;
+      }
+      if (rouletteTimer > 0) {
+        setRouletteTimer((prev) => prev - 1);
       } else {
         startSpin();
       }
@@ -65,7 +73,7 @@ export default function Roulette() {
     return () => {
       isMounted = false;
     };
-  }, [stockSellTime, startSpin]);
+  }, [rouletteTimer, setRouletteTimer, startSpin]);
 
   useEffect(() => {
     if (gameInfo.eventResult === '') return;
@@ -106,7 +114,7 @@ export default function Roulette() {
         onStopSpinning={handleSpinDone}
       />
       <Wrapper>
-        <Timer>남은 매도시간: {stockSellTime}</Timer>
+        <Timer>남은 매도시간: {rouletteTimer}</Timer>
       </Wrapper>
       {isEventModalOpen && <EventModal />}
       {isRolling && RouletteRollingSound}

--- a/fe/src/store/reducer/constants.ts
+++ b/fe/src/store/reducer/constants.ts
@@ -220,6 +220,7 @@ export const initialGame = {
   firstPlayerId: '',
   currentPlayerId: '',
   dice: [0, 0],
+  timer: 0,
   eventList: [],
   eventResult: '',
   isMoveFinished: false,

--- a/fe/src/store/reducer/index.ts
+++ b/fe/src/store/reducer/index.ts
@@ -64,6 +64,9 @@ const resetTeleportLocationAtom = atom(null, (_get, set) => {
   });
 });
 
+const timerAtom = focusAtom(gameInfoAtom, (optic) => optic.prop('timer'));
+export const useRouletteTimer = () => useAtom(timerAtom);
+
 export const useGameInfo = () => useAtom(gameInfoAtom);
 export const usePlayers = () => useAtom(playersAtom);
 

--- a/fe/src/store/reducer/type.ts
+++ b/fe/src/store/reducer/type.ts
@@ -31,6 +31,7 @@ export type GameInfoType = {
   firstPlayerId: string;
   currentPlayerId: string | null;
   dice: number[];
+  timer: number;
   eventList: RouletteEvent[];
   eventResult: string;
   isMoveFinished: boolean;
@@ -104,6 +105,7 @@ export type CellPayloadType = {
 };
 
 export type EventsPayloadType = {
+  timer: number;
   events: RouletteEvent[];
 };
 

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -208,6 +208,7 @@ export default function useGameReducer() {
             ...prev,
             game: {
               ...prev.game,
+              timer: payload.timer,
               eventList: [...payload.events],
               isArrived: false,
             },

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -350,6 +350,10 @@ export default function useGameReducer() {
         case 'locations': {
           return {
             ...prev,
+            game: {
+              ...prev.game,
+              isPlaying: true,
+            },
             players: prev.players.map((player) => {
               const payload = action.payload as LocationsPayloadType[];
 


### PR DESCRIPTION
## 📌 이슈번호
- #8 

## 🔑 Key changes
- 서버에서 룰렛 타이머를 받아오는 방식에 맞게 수정했습니다.
- 룰렛 타이머가 돌아가는 도중 eventResult가 왔을 때 이상하게 돌아가는 버그를 수정했습니다.
- 리듀서 locations 케이스에서 isPlaying: true 상태변경 추가
