### PR TITLE
[BE] 황금카드 기능 추가, API 리팩토링

### DIFF
--- a/be/src/main/java/codesquad/gaemimarble/config/CorsConfig.java
+++ b/be/src/main/java/codesquad/gaemimarble/config/CorsConfig.java
@@ -16,6 +16,7 @@ public class CorsConfig implements WebMvcConfigurer {
 			.allowedOrigins("*")
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
             .exposedHeaders(Constants.REFRESH_TOKEN)
-            .exposedHeaders(HttpHeaders.AUTHORIZATION);
+            .exposedHeaders(HttpHeaders.AUTHORIZATION)
+			.allowCredentials(true);
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/config/CorsConfig.java
+++ b/be/src/main/java/codesquad/gaemimarble/config/CorsConfig.java
@@ -16,7 +16,6 @@ public class CorsConfig implements WebMvcConfigurer {
 			.allowedOrigins("*")
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
             .exposedHeaders(Constants.REFRESH_TOKEN)
-            .exposedHeaders(HttpHeaders.AUTHORIZATION)
-			.allowCredentials(true);
+            .exposedHeaders(HttpHeaders.AUTHORIZATION);
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -45,6 +45,7 @@ import codesquad.gaemimarble.game.dto.response.userStatusBoard.GameUserBoardResp
 import codesquad.gaemimarble.game.entity.Player;
 import codesquad.gaemimarble.game.entity.TypeConstants;
 import codesquad.gaemimarble.game.service.GameService;
+import codesquad.gaemimarble.util.Constants;
 
 @RestController
 public class GameController {
@@ -281,8 +282,8 @@ public class GameController {
 	}
 
 	public void sendBailResult(GameBailRequest gameBailRequest) {
-		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.EXPENSE,
-			gameService.payExpense(gameBailRequest.getGameId(), gameBailRequest.getPlayerId(), 5_000_000)));
+		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.USER_STATUS_BOARD,
+			gameService.payExpense(gameBailRequest.getGameId(), gameBailRequest.getPlayerId(), Constants.BAIL_MONEY)));
 		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.DICE,
 			gameService.rollDice(gameBailRequest.getGameId(), gameBailRequest.getPlayerId())));
 	}

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -284,8 +284,9 @@ public class GameController {
 	public void sendBailResult(GameBailRequest gameBailRequest) {
 		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.USER_STATUS_BOARD,
 			gameService.payExpense(gameBailRequest.getGameId(), gameBailRequest.getPlayerId(), Constants.BAIL_MONEY)));
-		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.DICE,
-			gameService.rollDice(gameBailRequest.getGameId(), gameBailRequest.getPlayerId())));
+		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.PRISON_DICE,
+			gameService.prisonDice(GamePrisonDiceRequest.builder().gameId(gameBailRequest.getGameId()).playerId(
+				gameBailRequest.getPlayerId()).build())));
 	}
 
 	private void sendUserStatusBoardResponse(Long gameId, String playerId){

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -22,7 +22,8 @@ import codesquad.gaemimarble.game.dto.request.GameEventRequest;
 import codesquad.gaemimarble.game.dto.request.GameEventResultRequest;
 import codesquad.gaemimarble.game.dto.request.GamePrisonDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameReadyRequest;
-import codesquad.gaemimarble.game.dto.request.GameRobRequest;
+import codesquad.gaemimarble.game.dto.request.GoldCardRequest.GameDonationRequest;
+import codesquad.gaemimarble.game.dto.request.GoldCardRequest.GameRobRequest;
 import codesquad.gaemimarble.game.dto.request.GameRollDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
 import codesquad.gaemimarble.game.dto.request.GameStartRequest;
@@ -67,6 +68,7 @@ public class GameController {
 		typeMap.put(TypeConstants.ROB, GameRobRequest.class);
 		typeMap.put(TypeConstants.STATUS_BOARD, GameStatusBoardRequest.class);
 		typeMap.put(TypeConstants.CELL, GameCellArrivalRequest.class);
+		typeMap.put(TypeConstants.DONATION, GameDonationRequest.class);
 
 		this.handlers = new HashMap<>();
 		handlers.put(GameReadyRequest.class, req -> sendReadyStatus((GameReadyRequest)req));
@@ -83,6 +85,15 @@ public class GameController {
 		handlers.put(GameRobRequest.class, req -> sendRobResult((GameRobRequest)req));
 		handlers.put(GameStatusBoardRequest.class, req -> sendStatusBoard((GameStatusBoardRequest)req));
 		handlers.put(GameCellArrivalRequest.class, req -> sendCellArrival((GameCellArrivalRequest)req));
+		handlers.put(GameDonationRequest.class, req -> sendDonationResult((GameDonationRequest)req));
+	}
+
+
+	private void sendDonationResult(GameDonationRequest gameDonationRequest) {
+		List<Player> players = gameService.donate(gameDonationRequest);
+		players.forEach(
+			p -> socketDataSender.send(gameDonationRequest.getGameId(), new ResponseDTO<>(TypeConstants.USER_STATUS_BOARD,
+				gameService.createUserBoardResponse(p))));
 	}
 
 	private void sendRobResult(GameRobRequest gameRobRequest) {

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -277,16 +277,18 @@ public class GameController {
 	}
 
 	public void sendPrisonDiceResult(GamePrisonDiceRequest gamePrisonDiceRequest) {
+		Boolean hasPayed = false;
 		socketDataSender.send(gamePrisonDiceRequest.getGameId(), new ResponseDTO<>(TypeConstants.PRISON_DICE,
-			gameService.prisonDice(gamePrisonDiceRequest)));
+			gameService.prisonDice(gamePrisonDiceRequest, hasPayed)));
 	}
 
 	public void sendBailResult(GameBailRequest gameBailRequest) {
 		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.USER_STATUS_BOARD,
 			gameService.payExpense(gameBailRequest.getGameId(), gameBailRequest.getPlayerId(), Constants.BAIL_MONEY)));
+		Boolean hasPayed = true;
 		socketDataSender.send(gameBailRequest.getGameId(), new ResponseDTO<>(TypeConstants.PRISON_DICE,
 			gameService.prisonDice(GamePrisonDiceRequest.builder().gameId(gameBailRequest.getGameId()).playerId(
-				gameBailRequest.getPlayerId()).build())));
+				gameBailRequest.getPlayerId()).build(),hasPayed )));
 	}
 
 	private void sendUserStatusBoardResponse(Long gameId, String playerId){

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameBailRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameBailRequest.java
@@ -2,8 +2,10 @@ package codesquad.gaemimarble.game.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class GameBailRequest {
 	Long gameId;
 	String playerId;

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameCellArrivalRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameCellArrivalRequest.java
@@ -1,0 +1,16 @@
+package codesquad.gaemimarble.game.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameCellArrivalRequest {
+	private final Long gameId;
+	private final String playerId;
+
+	@Builder
+	public GameCellArrivalRequest(Long gameId, String playerId) {
+		this.gameId = gameId;
+		this.playerId = playerId;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameCellArrivalRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameCellArrivalRequest.java
@@ -2,11 +2,13 @@ package codesquad.gaemimarble.game.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class GameCellArrivalRequest {
-	private final Long gameId;
-	private final String playerId;
+	private Long gameId;
+	private String playerId;
 
 	@Builder
 	public GameCellArrivalRequest(Long gameId, String playerId) {

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GamePrisonDiceRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GamePrisonDiceRequest.java
@@ -2,8 +2,10 @@ package codesquad.gaemimarble.game.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class GamePrisonDiceRequest {
 	private Long gameId;
 	private String playerId;

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameStatusBoardRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameStatusBoardRequest.java
@@ -1,0 +1,14 @@
+package codesquad.gaemimarble.game.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameStatusBoardRequest {
+	private final Long gameId;
+
+	@Builder
+	public GameStatusBoardRequest(Long gameId) {
+		this.gameId = gameId;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameStatusBoardRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameStatusBoardRequest.java
@@ -2,10 +2,12 @@ package codesquad.gaemimarble.game.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class GameStatusBoardRequest {
-	private final Long gameId;
+	private Long gameId;
 
 	@Builder
 	public GameStatusBoardRequest(Long gameId) {

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameArrestRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameArrestRequest.java
@@ -6,15 +6,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class GameDonationRequest {
+public class GameArrestRequest {
 	private Long gameId;
-	private String playerId;
-	private String receiverId;
+	private String targetId;
 
 	@Builder
-	private GameDonationRequest(Long gameId, String playerId, String receiverId) {
+	public GameArrestRequest(Long gameId, String targetId) {
 		this.gameId = gameId;
-		this.playerId = playerId;
-		this.receiverId = receiverId;
+		this.targetId = targetId;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameArrestRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameArrestRequest.java
@@ -8,10 +8,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GameArrestRequest {
 	private Long gameId;
+	private String playerId;
 	private String targetId;
 
 	@Builder
-	public GameArrestRequest(Long gameId, String targetId) {
+	public GameArrestRequest(Long gameId, String playerId, String targetId) {
+		this.playerId = playerId;
 		this.gameId = gameId;
 		this.targetId = targetId;
 	}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameDonationRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameDonationRequest.java
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 public class GameDonationRequest {
 	private Long gameId;
 	private String playerId;
-	private String receiverId;
+	private String targetId;
 
 	@Builder
-	private GameDonationRequest(Long gameId, String playerId, String receiverId) {
+	private GameDonationRequest(Long gameId, String playerId, String targetId) {
 		this.gameId = gameId;
 		this.playerId = playerId;
-		this.receiverId = receiverId;
+		this.targetId = targetId;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameDonationRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameDonationRequest.java
@@ -1,0 +1,18 @@
+package codesquad.gaemimarble.game.dto.request.GoldCardRequest;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameDonationRequest {
+	private Long gameId;
+	private String playerId;
+	private String receiverId;
+
+	@Builder
+	private GameDonationRequest(Long gameId, String playerId, String receiverId) {
+		this.gameId = gameId;
+		this.playerId = playerId;
+		this.receiverId = receiverId;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameRobRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameRobRequest.java
@@ -1,4 +1,4 @@
-package codesquad.gaemimarble.game.dto.request;
+package codesquad.gaemimarble.game.dto.request.GoldCardRequest;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameStockManipulationRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameStockManipulationRequest.java
@@ -6,15 +6,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class GameDonationRequest {
+public class GameStockManipulationRequest {
 	private Long gameId;
-	private String playerId;
-	private String receiverId;
+	private String stockName;
 
 	@Builder
-	private GameDonationRequest(Long gameId, String playerId, String receiverId) {
+	public GameStockManipulationRequest(Long gameId,String stockName) {
 		this.gameId = gameId;
-		this.playerId = playerId;
-		this.receiverId = receiverId;
+		this.stockName = stockName;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameViciousRumorRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GoldCardRequest/GameViciousRumorRequest.java
@@ -6,15 +6,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class GameDonationRequest {
+public class GameViciousRumorRequest {
 	private Long gameId;
-	private String playerId;
-	private String receiverId;
+	private String stockName;
 
 	@Builder
-	private GameDonationRequest(Long gameId, String playerId, String receiverId) {
+	private GameViciousRumorRequest(Long gameId, String stockName) {
 		this.gameId = gameId;
-		this.playerId = playerId;
-		this.receiverId = receiverId;
+		this.stockName = stockName;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameCellResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameCellResponse.java
@@ -7,14 +7,10 @@ import lombok.Getter;
 public class GameCellResponse {
 	private String playerId;
 	private Integer location;
-	private Integer salary;
-	private Integer dividend;
 
 	@Builder
-	public GameCellResponse(String playerId, Integer location, Integer salary, Integer dividend) {
+	public GameCellResponse(String playerId, Integer location) {
 		this.playerId = playerId;
 		this.location = location;
-		this.salary = salary;
-		this.dividend = dividend;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameGoldCardResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameGoldCardResponse.java
@@ -5,11 +5,13 @@ import lombok.Getter;
 
 @Getter
 public class GameGoldCardResponse {
+	private String cardType;
 	private String title;
 	private String description;
 
 	@Builder
-	private GameGoldCardResponse(String title, String description) {
+	private GameGoldCardResponse(String cardType, String title, String description) {
+		this.cardType = cardType;
 		this.title = title;
 		this.description = description;
 	}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameTeleportResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameTeleportResponse.java
@@ -5,10 +5,12 @@ import lombok.Getter;
 
 @Getter
 public class GameTeleportResponse {
+	private final String playerId;
 	private final Integer location;
 
 	@Builder
-	private GameTeleportResponse(Integer location) {
+	private GameTeleportResponse(String playerId, Integer location) {
+		this.playerId = playerId;
 		this.location = location;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/CurrentPlayerInfo.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/CurrentPlayerInfo.java
@@ -11,6 +11,7 @@ public class CurrentPlayerInfo {
 	private Integer order;
 	private Integer countDouble;
 	private Boolean rolledDouble;
+	private Boolean hasMoved;
 
 	@Builder
 	private CurrentPlayerInfo(String playerId, Integer order) {
@@ -18,6 +19,7 @@ public class CurrentPlayerInfo {
 		this.order = order;
 		this.countDouble = 0;
 		this.rolledDouble = false;
+		this.hasMoved = false;
 	}
 
 	public int increaseCountDouble() {
@@ -31,6 +33,12 @@ public class CurrentPlayerInfo {
 		this.countDouble = 0;
 		this.rolledDouble = false;
 	}
+	public void move(){
+		hasMoved = true;
+	}
+	public void resetMove() {
+		hasMoved = false;
+	}
 
 	public void resetCountDouble() {
 		this.countDouble = 0;
@@ -39,4 +47,6 @@ public class CurrentPlayerInfo {
 	public void initRolledDouble() {
 		rolledDouble = false;
 	}
+
+
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
@@ -22,6 +22,7 @@ public enum GoldCard {
 	}
 
 	public static GoldCard getRandomGoldCard() {
-		return GoldCard.values()[(int) (Math.random() * GoldCard.values().length)];
+		return GoldCard.MANIPULATION;
+		// return GoldCard.values()[(int) (Math.random() * GoldCard.values().length)];
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
@@ -22,7 +22,7 @@ public enum GoldCard {
 	}
 
 	public static GoldCard getRandomGoldCard() {
-		return GoldCard.MANIPULATION;
+		return GoldCard.ARREST;
 		// return GoldCard.values()[(int) (Math.random() * GoldCard.values().length)];
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
@@ -4,13 +4,19 @@ import lombok.Getter;
 
 @Getter
 public enum GoldCard {
-	ROB("강탈", "선택한 플레이어에게서 1000만원을 강탈한다."),
-	DONATION("기부", "선택한 플레이어에게 1000만원을 기부한다."),
+	ROB("rob","강탈", "선택한 플레이어에게서 1000만원을 강탈한다."),
+	DONATION("donation","기부", "선택한 플레이어에게 1000만원을 기부한다."),
+	VICIOUS_RUMOR("viciousRumor","악성 루머 양산", "선택한 기업의 주가 -30%"),
+	MANIPULATION("manipulation","주가 조작", "선택한 기업의 주가 + 30%"),
+	TELEPORT("teleport","순간이동", "원하는 칸으로 순간이동"),
+	ARREST("arrest","검찰 조사", "원하는 플레이어를 유치장으로 보낸다.");
 
+	private final String cardType;
 	private final String title;
 	private final String description;
 
-	GoldCard(String title, String description) {
+	GoldCard(String cardType, String title, String description) {
+		this.cardType = cardType;
 		this.title = title;
 		this.description = description;
 	}

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum GoldCard {
-	ROB("강탈", "선택한 플레이어에게서 1000만원을 강탈한다.");
+	ROB("강탈", "선택한 플레이어에게서 1000만원을 강탈한다."),
+	DONATION("기부", "선택한 플레이어에게 1000만원을 기부한다."),
 
 	private final String title;
 	private final String description;

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -23,4 +23,5 @@ public final class TypeConstants {
 	public static final String GAME_OVER = "gameOver";
 	public static final String CURRENT_PLAYER = "currentPlayer";
 	public static final String LOCATIONS = "locations";
+	public static final String DONATION = "donation";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -24,4 +24,7 @@ public final class TypeConstants {
 	public static final String CURRENT_PLAYER = "currentPlayer";
 	public static final String LOCATIONS = "locations";
 	public static final String DONATION = "donation";
+	public static final String VICIOUS_RUMOR = "viciousRumor";
+	public static final String MANIPULATION = "manipulation";
+	public static final String ARREST = "arrest";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -130,10 +130,8 @@ public class GameService {
 		if(gameStatus.getCurrentPlayerInfo().getHasMoved()){
 			throw new PlayTimeException("주사위를 이미 굴렸습니다.", playerId, gameId);
 		}
-		// int dice1 = (int)(Math.random() * 6) + 1;
-		// int dice2 = (int)(Math.random() * 6) + 1;
-		int dice1 = 5;
-		int dice2 = 4;
+		int dice1 = (int)(Math.random() * 6) + 1;
+		int dice2 = (int)(Math.random() * 6) + 1;
 
 		if (dice1 == dice2) {
 			int countDouble = gameStatus.getCurrentPlayerInfo().increaseCountDouble();

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -17,7 +17,8 @@ import codesquad.gaemimarble.game.dto.request.GameEndTurnRequest;
 import codesquad.gaemimarble.game.dto.request.GameEventResultRequest;
 import codesquad.gaemimarble.game.dto.request.GamePrisonDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameReadyRequest;
-import codesquad.gaemimarble.game.dto.request.GameRobRequest;
+import codesquad.gaemimarble.game.dto.request.GoldCardRequest.GameDonationRequest;
+import codesquad.gaemimarble.game.dto.request.GoldCardRequest.GameRobRequest;
 import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
 import codesquad.gaemimarble.game.dto.request.GameStockBuyRequest;
 import codesquad.gaemimarble.game.dto.request.GameTeleportRequest;
@@ -410,6 +411,7 @@ public class GameService {
 	public GameGoldCardResponse selectGoldCard(Long gameId, String playerId) {
 		GoldCard goldCard = GoldCard.getRandomGoldCard();
 		return GameGoldCardResponse.builder()
+			.cardType(goldCard.name().toLowerCase())
 			.title(goldCard.getTitle())
 			.description(goldCard.getDescription())
 			.build();
@@ -484,5 +486,13 @@ public class GameService {
 					.build());
 		}
 		return gameEventListResponse;
+	}
+
+	public List<Player> donate(GameDonationRequest gameDonationRequest) {
+		Player giver = gameRepository.getPlayer(gameDonationRequest.getGameId(), gameDonationRequest.getPlayerId());
+		giver.addCashAsset(-10_000_000);
+		Player receiver = gameRepository.getPlayer(gameDonationRequest.getGameId(), gameDonationRequest.getReceiverId());
+		receiver.addCashAsset(10_000_000);
+		return List.of(giver, receiver);
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -130,8 +130,10 @@ public class GameService {
 		if(gameStatus.getCurrentPlayerInfo().getHasMoved()){
 			throw new PlayTimeException("주사위를 이미 굴렸습니다.", playerId, gameId);
 		}
-		int dice1 = (int)(Math.random() * 6) + 1;
-		int dice2 = (int)(Math.random() * 6) + 1;
+		// int dice1 = (int)(Math.random() * 6) + 1;
+		// int dice2 = (int)(Math.random() * 6) + 1;
+		int dice1 = 5;
+		int dice2 = 4;
 
 		if (dice1 == dice2) {
 			int countDouble = gameStatus.getCurrentPlayerInfo().increaseCountDouble();

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -148,12 +148,14 @@ public class GameService {
 
 		int location = player.getLocation();
 		int salary = 0;
+		int dividend = 0;
 		if (location > 23) {
 			salary = 5_000_000;
+			dividend = (int)((player.getStockAsset() * 5) / 100);
+			dividend = (dividend / 100_000) * 100_000;
+
 			player.setLocation(location % 24);
 		}
-		int dividend = (int)((player.getStockAsset() * 5) / 100);
-		dividend = (dividend / 100_000) * 100_000;
 		player.addCashAsset(salary + dividend);
 
 		return GameCellResponse.builder()

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -41,6 +41,7 @@ import codesquad.gaemimarble.game.dto.response.PlayerAsset;
 import codesquad.gaemimarble.game.dto.response.UserRankingResponse;
 import codesquad.gaemimarble.game.dto.response.generalStatusBoard.GameStatusBoardResponse;
 import codesquad.gaemimarble.game.dto.response.userStatusBoard.GameUserBoardResponse;
+import codesquad.gaemimarble.game.dto.response.userStatusBoard.GameUserStatusBoardResponse;
 import codesquad.gaemimarble.game.entity.Board;
 import codesquad.gaemimarble.game.entity.CurrentPlayerInfo;
 import codesquad.gaemimarble.game.entity.Events;
@@ -160,13 +161,10 @@ public class GameService {
 			.build();
 	}
 
-	public GameExpenseResponse payExpense(Long gameId, String playerId, int expense) {
+	public GameUserBoardResponse payExpense(Long gameId, String playerId, int expense) {
 		Player player = gameRepository.getGameStatus(gameId).getPlayer(playerId);
 		player.addCashAsset(-expense);
-		return GameExpenseResponse.builder()
-			.playerId(player.getPlayerId())
-			.amount(expense)
-			.build();
+		return createUserBoardResponse(player);
 	}
 
 	public GameEventListResponse selectEvents(Long gameId) {

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -31,7 +31,6 @@ import codesquad.gaemimarble.game.dto.response.GameEnterResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventListResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventResponse;
-import codesquad.gaemimarble.game.dto.response.GameExpenseResponse;
 import codesquad.gaemimarble.game.dto.response.GameGoldCardResponse;
 import codesquad.gaemimarble.game.dto.response.GameLocationResponse;
 import codesquad.gaemimarble.game.dto.response.GamePrisonDiceResponse;
@@ -41,7 +40,6 @@ import codesquad.gaemimarble.game.dto.response.PlayerAsset;
 import codesquad.gaemimarble.game.dto.response.UserRankingResponse;
 import codesquad.gaemimarble.game.dto.response.generalStatusBoard.GameStatusBoardResponse;
 import codesquad.gaemimarble.game.dto.response.userStatusBoard.GameUserBoardResponse;
-import codesquad.gaemimarble.game.dto.response.userStatusBoard.GameUserStatusBoardResponse;
 import codesquad.gaemimarble.game.entity.Board;
 import codesquad.gaemimarble.game.entity.CurrentPlayerInfo;
 import codesquad.gaemimarble.game.entity.Events;
@@ -156,8 +154,6 @@ public class GameService {
 		return GameCellResponse.builder()
 			.playerId(player.getPlayerId())
 			.location(player.getLocation())
-			.salary(salary)
-			.dividend(dividend)
 			.build();
 	}
 

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -403,7 +403,7 @@ public class GameService {
 
 	}
 
-	public GamePrisonDiceResponse prisonDice(GamePrisonDiceRequest gamePrisonDiceRequest) {
+	public GamePrisonDiceResponse prisonDice(GamePrisonDiceRequest gamePrisonDiceRequest, Boolean hasPayed) {
 		GameStatus gameStatus = gameRepository.getGameStatus(gamePrisonDiceRequest.getGameId());
 		Player player = gameStatus.getPlayer(gamePrisonDiceRequest.getPlayerId());
 
@@ -412,13 +412,22 @@ public class GameService {
 
 		if (dice1 == dice2) {
 			player.escapePrison(dice1 + dice2);
+			gameStatus.getCurrentPlayerInfo().move();
 		} else {
 			player.increasePrisonCount();
-			if (player.getPrisonCount() == 3) {
+			if (player.getPrisonCount() == 3 || hasPayed) {
+				gameStatus.getCurrentPlayerInfo().increaseCountDouble();
 				player.escapePrison(dice1 + dice2);
+				gameStatus.getCurrentPlayerInfo().move();
+				return GamePrisonDiceResponse.builder()
+						.playerId(player.getPlayerId())
+						.dice1(dice1)
+						.dice2(dice2)
+						.hasEscaped(true)
+						.build();
+
 			}
 		}
-
 		return GamePrisonDiceResponse.builder()
 			.playerId(player.getPlayerId())
 			.dice1(dice1)

--- a/be/src/main/java/codesquad/gaemimarble/util/Constants.java
+++ b/be/src/main/java/codesquad/gaemimarble/util/Constants.java
@@ -3,7 +3,7 @@ package codesquad.gaemimarble.util;
 public class Constants {
 	public static final String PLAYER_ID = "playerId";
 	public static final String TOKEN_PREFIX = "Bearer ";
-	public static final String REFRESH_TOKEN = "Refresh-Token";
+	public static final String REFRESH_TOKEN = "RefreshToken";
 	public static final int SELLING_TIME = 10;
 	public static final int GAME_OVER_ROUND = 5;
 	public static final int VICIOUS_RUMOR_STOCK_DROP = -30;

--- a/be/src/main/java/codesquad/gaemimarble/util/Constants.java
+++ b/be/src/main/java/codesquad/gaemimarble/util/Constants.java
@@ -8,4 +8,5 @@ public class Constants {
 	public static final int GAME_OVER_ROUND = 5;
 	public static final int VICIOUS_RUMOR_STOCK_DROP = -30;
 	public static final int STOCK_MANIPULATION_INCREASE = 30;
+	public static final	int BAIL_MONEY = 5_000_000;
 }

--- a/be/src/main/java/codesquad/gaemimarble/util/Constants.java
+++ b/be/src/main/java/codesquad/gaemimarble/util/Constants.java
@@ -6,4 +6,6 @@ public class Constants {
 	public static final String REFRESH_TOKEN = "Refresh-Token";
 	public static final int SELLING_TIME = 10;
 	public static final int GAME_OVER_ROUND = 5;
+	public static final int VICIOUS_RUMOR_STOCK_DROP = -30;
+	public static final int STOCK_MANIPULATION_INCREASE = 30;
 }


### PR DESCRIPTION
## 📌 이슈번호
- #13 

## 🔑 Key changes
- 전체현황판 응답 시, 개인현황판 함께 응답하도록 수정
- 칸도착 분리
- 개인현황판 분리
- 황금카드 리팩토링 & 기능 추가
  - 기부, 악성루머양산, 주가조작, 검찰조사
- 순간이동 파라미터 수정
- DTO NoArgs 누락 추가 
- 주사위 중복 요청 발생 방지
- 개인 현황판 타입, 버그 수정
