### PR TITLE
[FE] useHover 커스텀 훅 로직 변경

### DIFF
--- a/fe/src/components/GameBoard/CenterArea.tsx
+++ b/fe/src/components/GameBoard/CenterArea.tsx
@@ -4,7 +4,7 @@ import useMoveToken from '@hooks/useMoveToken';
 import { usePlayerIdValue } from '@store/index';
 import {
   useGameInfoValue,
-  usePlayersValue,
+  usePlayers,
   useResetTeleportLocation,
   useSetGameInfo,
 } from '@store/reducer';
@@ -27,13 +27,19 @@ export default function CenterArea({
   targetLocation,
   resetTargetLocation,
 }: CenterAreaProps) {
-  const { hoverRef: bailRef, isHover: isBailBtnHover } =
-    useHover<HTMLButtonElement>();
-  const { hoverRef: escapeRef, isHover: isEscapeBtnHover } =
-    useHover<HTMLButtonElement>();
+  const {
+    handleMouseEnter: handleBailBtnEnter,
+    handleMouseLeave: handleBailBtnLeave,
+    isHover: isBailBtnHover,
+  } = useHover();
+  const {
+    handleMouseEnter: handleEscapeBtnEnter,
+    handleMouseLeave: handleEscapeBtnLeave,
+    isHover: isEscapeBtnHover,
+  } = useHover();
   const { gameId } = useParams();
   const playerId = usePlayerIdValue();
-  const players = usePlayersValue();
+  const [players, setPlayers] = usePlayers();
   const { currentPlayerId, firstPlayerId, isMoveFinished, teleportLocation } =
     useGameInfoValue();
   const setGameInfo = useSetGameInfo();
@@ -125,7 +131,23 @@ export default function CenterArea({
       gameId,
       playerId,
     };
+
     sendJsonMessage(message);
+
+    setPlayers((prev) => {
+      return prev.map((player) => {
+        if (player.playerId === playerId) {
+          return {
+            ...player,
+            gameBoard: {
+              ...player.gameBoard,
+              hasEscaped: true,
+            },
+          };
+        }
+        return player;
+      });
+    });
   };
 
   const handleEscape = () => {
@@ -195,11 +217,18 @@ export default function CenterArea({
       )}
       {prisonStart && (
         <Wrapper>
-          <Button ref={bailRef} onClick={handleBail}>
-            {/* Memo: 호버시 내부 텍스트가 안 바뀌는 버그 발견 */}
+          <Button
+            onMouseEnter={handleBailBtnEnter}
+            onMouseLeave={handleBailBtnLeave}
+            onClick={handleBail}
+          >
             {isBailBtnHover ? '-5,000,000₩' : '보석금 지불'}
           </Button>
-          <Button ref={escapeRef} onClick={handleEscape}>
+          <Button
+            onMouseEnter={handleEscapeBtnEnter}
+            onMouseLeave={handleEscapeBtnLeave}
+            onClick={handleEscape}
+          >
             {isEscapeBtnHover ? '주사위 더블시 탈출' : '굴려서 탈출'}
           </Button>
         </Wrapper>

--- a/fe/src/components/Header/HomeHeader.tsx
+++ b/fe/src/components/Header/HomeHeader.tsx
@@ -14,7 +14,7 @@ import { Icon } from '../icon/Icon';
 
 export default function HomeHeader() {
   const navigate = useNavigate();
-  const { hoverRef, isHover } = useHover<HTMLDivElement>();
+  const { handleMouseEnter, handleMouseLeave, isHover } = useHover();
   const setPlayer = useSetPlayer();
   const setAccessToken = useSetAccessToken();
   const setRefreshToken = useSetRefreshToken();
@@ -50,13 +50,16 @@ export default function HomeHeader() {
               onClick={togglePlayingSound}
             />
           </IconContainer>
-          <User ref={hoverRef}>
+          <IconContainer
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
             {isHover ? (
               <Icon name="exit" size="3rem" onClick={handleLogout} />
             ) : (
               <Icon name="sample" size="3rem" />
             )}
-          </User>
+          </IconContainer>
         </IconWrapper>
       </StyledHeader>
       {HomeBgm}
@@ -101,11 +104,4 @@ const IconContainer = styled.div`
       stroke: ${({ theme: { color } }) => color.accentText};
     }
   }
-`;
-
-const User = styled.div`
-  width: 3rem;
-  height: 3rem;
-  border-radius: ${({ theme: { radius } }) => radius.half};
-  background-color: ${({ theme: { color } }) => color.neutralBackground};
 `;

--- a/fe/src/components/Player/PlayerStock.tsx
+++ b/fe/src/components/Player/PlayerStock.tsx
@@ -13,20 +13,15 @@ type PlayerStockProps = {
 export default function PlayerStock({ stockInfo }: PlayerStockProps) {
   const { positionRef, position, calcPosition } =
     useTooltipPosition<HTMLImageElement>();
-  const { hoverRef, isHover } = useHover();
+  const { handleMouseEnter, handleMouseLeave, isHover } = useHover();
   const stockList = useStocksValue();
 
-  const imgRef = (element: HTMLImageElement | null) => {
-    if (element) {
-      positionRef.current = element;
-      hoverRef.current = element;
-    }
-  };
-
-  const handleMouseEnter = (event: React.MouseEvent<HTMLImageElement>) => {
+  const handleStockImgEnter = (event: React.MouseEvent<HTMLImageElement>) => {
     if (calcPosition) {
       calcPosition(event);
     }
+
+    handleMouseEnter();
   };
 
   const stockLogo = stockList.find(
@@ -37,9 +32,10 @@ export default function PlayerStock({ stockInfo }: PlayerStockProps) {
     <>
       <StockImgWrapper>
         <StockImg
-          ref={imgRef}
+          ref={positionRef}
+          onMouseEnter={handleStockImgEnter}
+          onMouseLeave={handleMouseLeave}
           src={cellImageMap[stockLogo]}
-          onMouseEnter={handleMouseEnter}
         />
       </StockImgWrapper>
       {isHover && (

--- a/fe/src/hooks/useHover.ts
+++ b/fe/src/hooks/useHover.ts
@@ -1,18 +1,12 @@
-import {
-  MutableRefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useState } from 'react';
 
-type HoverReturnType<T extends HTMLElement> = {
-  hoverRef: MutableRefObject<T | null>;
+type HoverReturnType = {
+  handleMouseEnter: () => void;
+  handleMouseLeave: () => void;
   isHover: boolean;
 };
 
-export default function useHover<T extends HTMLElement>(): HoverReturnType<T> {
-  const hoverRef = useRef<T>(null);
+export default function useHover(): HoverReturnType {
   const [isHover, setIsHover] = useState(false);
 
   const handleMouseEnter = useCallback(() => {
@@ -23,17 +17,5 @@ export default function useHover<T extends HTMLElement>(): HoverReturnType<T> {
     setIsHover(false);
   }, []);
 
-  useEffect(() => {
-    const currentRef = hoverRef.current;
-
-    currentRef?.addEventListener('mouseenter', handleMouseEnter);
-    currentRef?.addEventListener('mouseleave', handleMouseLeave);
-
-    return () => {
-      currentRef?.removeEventListener('mouseenter', handleMouseEnter);
-      currentRef?.removeEventListener('mouseleave', handleMouseLeave);
-    };
-  }, [handleMouseEnter, handleMouseLeave]);
-
-  return { hoverRef, isHover };
+  return { handleMouseEnter, handleMouseLeave, isHover };
 }

--- a/fe/src/store/reducer/constants.ts
+++ b/fe/src/store/reducer/constants.ts
@@ -51,7 +51,6 @@ export const INITIAL_PLAYER = [
       stockAsset: 0,
       totalAsset: 0,
       stockList: [],
-      hasEscaped: true,
     },
     gameBoard: {
       ref: null,


### PR DESCRIPTION
## 📌 이슈번호
- #21 

## 🔑 Key changes
- useHover 로직 변경
- 보석금 지불 후 hasEscaped 상태 true로 변경
- 필요없는 상태 삭제

## 👋 To reviewers
- useHover에서 ref를 반환하지 않고 마우스 enter, leave 핸들러 함수를 반환하도록 변경했습니다
- useHover 사용하는 부분 모두 수정했습니다
- 보석금 지불하는 handler 함수인 handleBail 함수에 hasEscaped 상태 변경 로직 추가했습니다
- 초기 player상태의 player3에만 userStatusBoard 안에 hasEscaped가 있어서 삭제했습니다
