### PR TITLE
[FE] 황금카드 분리

### DIFF
--- a/fe/src/components/Modal/GoldCardModal/GoldCardNoTarget.tsx
+++ b/fe/src/components/Modal/GoldCardModal/GoldCardNoTarget.tsx
@@ -1,0 +1,26 @@
+import { styled } from 'styled-components';
+
+type GoldCardNoTargetProps = { handleClickButton: () => void };
+
+export default function GoldCardNoTarget({
+  handleClickButton,
+}: GoldCardNoTargetProps) {
+  return (
+    <>
+      <Instruction>
+        선택하기 버튼을 누른 후 이동할 칸을 선택 및 이동하세요
+      </Instruction>
+      <AttackButton onClick={handleClickButton}>선택하기</AttackButton>
+    </>
+  );
+}
+
+const Instruction = styled.span``;
+
+const AttackButton = styled.button`
+  width: 7rem;
+  height: 3rem;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: ${({ theme }) => theme.color.accentText};
+  background-color: ${({ theme }) => theme.color.accentBackground};
+`;

--- a/fe/src/components/Modal/GoldCardModal/GoldCardPlayer.tsx
+++ b/fe/src/components/Modal/GoldCardModal/GoldCardPlayer.tsx
@@ -1,0 +1,72 @@
+import { usePlayersValue } from '@store/reducer';
+import { styled } from 'styled-components';
+import { DefaultTheme } from 'styled-components/dist/types';
+
+type GoldCardPlayerProps = {
+  targetPlayer: string;
+  handleChoosePlayer: (target: string) => void;
+  handleClickButton: () => void;
+};
+
+export default function GoldCardPlayer({
+  targetPlayer,
+  handleChoosePlayer,
+  handleClickButton,
+}: GoldCardPlayerProps) {
+  const players = usePlayersValue();
+
+  const targetPlayers = players.filter((player) => player.playerId);
+
+  return (
+    <>
+      <Instruction>타겟 플레이어를 선택하세요</Instruction>
+      <PlayerToggleWrapper>
+        {targetPlayers.map((player) => (
+          <PlayerToggle
+            key={player.playerId}
+            onClick={() => handleChoosePlayer(player.playerId)}
+            $isTarget={player.playerId === targetPlayer}
+            $order={player.order}
+          >
+            {player.playerId}
+          </PlayerToggle>
+        ))}
+      </PlayerToggleWrapper>
+      <Target>타겟: {targetPlayer}</Target>
+      <AttackButton onClick={handleClickButton}>선택완료</AttackButton>
+    </>
+  );
+}
+
+const Instruction = styled.span``;
+
+const PlayerToggleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 3rem;
+`;
+
+const PlayerToggle = styled.button<{ $isTarget: boolean; $order: number }>`
+  width: 5rem;
+  height: 3rem;
+  border: ${({ theme, $isTarget }) =>
+    $isTarget ? 'none' : `1px solid ${theme.color.neutralBorder}`};
+  border-radius: ${({ theme }) => theme.radius.small};
+  color: ${({ theme, $isTarget }) =>
+    $isTarget ? theme.color.accentText : theme.color.neutralText};
+  background-color: ${({ theme, $order, $isTarget }) =>
+    $isTarget
+      ? theme.color[`player${$order}` as keyof DefaultTheme['color']]
+      : 'none'};
+`;
+
+const Target = styled.span``;
+
+const AttackButton = styled.button`
+  width: 7rem;
+  height: 3rem;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: ${({ theme }) => theme.color.accentText};
+  background-color: ${({ theme }) => theme.color.accentBackground};
+`;

--- a/fe/src/components/Modal/GoldCardModal/GoldCardStock.tsx
+++ b/fe/src/components/Modal/GoldCardModal/GoldCardStock.tsx
@@ -1,0 +1,67 @@
+import { useStocksValue } from '@store/reducer';
+import { styled } from 'styled-components';
+
+type GoldCardStockProps = {
+  targetStock: string;
+  handleChooseStock: (target: string) => void;
+  handleClickButton: () => void;
+};
+
+export default function GoldCardStock({
+  targetStock,
+  handleChooseStock,
+  handleClickButton,
+}: GoldCardStockProps) {
+  const stocks = useStocksValue();
+
+  return (
+    <>
+      <Instruction>타겟 주식을 선택하세요</Instruction>
+      <StockToggleWrapper>
+        {stocks.map((stock) => (
+          <StockToggle
+            key={stock.name}
+            onClick={() => handleChooseStock(stock.name)}
+            $isTarget={stock.name === targetStock}
+          >
+            {stock.name}
+          </StockToggle>
+        ))}
+      </StockToggleWrapper>
+      <Target>타겟: {targetStock}</Target>
+      <AttackButton onClick={handleClickButton}>선택완료</AttackButton>
+    </>
+  );
+}
+
+const Instruction = styled.span``;
+
+const StockToggleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const StockToggle = styled.button<{ $isTarget: boolean }>`
+  width: 7rem;
+  height: 3rem;
+  border: ${({ theme, $isTarget }) =>
+    $isTarget ? 'none' : `1px solid ${theme.color.neutralBorder}`};
+  border-radius: ${({ theme }) => theme.radius.small};
+  color: ${({ theme, $isTarget }) =>
+    $isTarget ? theme.color.accentText : theme.color.neutralText};
+  background-color: ${({ theme, $isTarget }) =>
+    $isTarget ? theme.color.accentSecondary : 'none'};
+`;
+
+const Target = styled.span``;
+
+const AttackButton = styled.button`
+  width: 7rem;
+  height: 3rem;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: ${({ theme }) => theme.color.accentText};
+  background-color: ${({ theme }) => theme.color.accentBackground};
+`;

--- a/fe/src/components/Modal/GoldCardModal/constants.ts
+++ b/fe/src/components/Modal/GoldCardModal/constants.ts
@@ -1,0 +1,3 @@
+export const NEED_PLAYER = ['rob', 'donation', 'arrest'];
+export const NEED_STOCK = ['manipulation', 'viciousRumor'];
+export const NEED_NOTHING = ['teleport'];

--- a/fe/src/store/reducer/constants.ts
+++ b/fe/src/store/reducer/constants.ts
@@ -232,7 +232,7 @@ export const INITIAL_GAME = {
   eventResult: '',
   isMoveFinished: false,
   teleportLocation: null,
-  goldCardInfo: { title: '', description: '' },
+  goldCardInfo: { cardType: '', title: '', description: '' },
   isArrived: false,
   ranking: [],
 };

--- a/fe/src/store/reducer/index.ts
+++ b/fe/src/store/reducer/index.ts
@@ -28,7 +28,7 @@ const resetGoldCardAtom = atom(null, (_get, set) => {
   set(gameInfoAtom, (prev) => {
     return {
       ...prev,
-      goldCardInfo: { title: '', description: '' },
+      goldCardInfo: { cardType: '', title: '', description: '' },
     };
   });
 });

--- a/fe/src/store/reducer/type.ts
+++ b/fe/src/store/reducer/type.ts
@@ -36,6 +36,7 @@ export type GameInfoType = {
   isMoveFinished: boolean;
   teleportLocation: number | null;
   goldCardInfo: {
+    cardType: string;
     title: string;
     description: string;
   };
@@ -134,6 +135,7 @@ export type RouletteEvent = {
 export type PlayerStatusType = 'default' | 'prison' | 'teleport' | 'event';
 
 export type GoldCardPayloadType = {
+  cardType: string;
   title: string;
   description: string;
 };

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -228,6 +228,7 @@ export default function useGameReducer() {
             game: {
               ...prev.game,
               goldCardInfo: {
+                cardType: payload.cardType,
                 title: payload.title,
                 description: payload.description,
               },


### PR DESCRIPTION
## 📌 이슈번호
- #23 

## 🔑 Key changes
- 황금 카드 공통 컴포넌트화
- 황금 카드 컴포넌트 분리
- 황금 카드 타입별로 player, stock, no target 케이스로 분리
- 스토어 타입 및 리듀서 수정

## 👋 To reviewers
- 황금 카드 검찰 조사 제외하고 구현 완료했습니다
