### PR TITLE
[FE] 황금 카드 랜더링 버그 수정

### DIFF
--- a/fe/src/components/Modal/GoldCardModal/GoldCardStock.tsx
+++ b/fe/src/components/Modal/GoldCardModal/GoldCardStock.tsx
@@ -39,7 +39,7 @@ const Instruction = styled.span``;
 const StockToggleWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 1rem;
 `;

--- a/fe/src/pages/GamePage.tsx
+++ b/fe/src/pages/GamePage.tsx
@@ -17,7 +17,7 @@ import Confetti from 'react-confetti';
 import { useNavigate } from 'react-router-dom';
 import useWebSocket from 'react-use-websocket';
 import { styled } from 'styled-components';
-import { STOCK_LOCATION } from './constants';
+import { GOLD_CARD_LOCATIONS, STOCK_LOCATION } from './constants';
 
 export default function GamePage() {
   const navigate = useNavigate();
@@ -49,8 +49,12 @@ export default function GamePage() {
     (player) => player.playerId === playerId
   )?.location;
   const isLocatedStockCell = STOCK_LOCATION.includes(currentLocation ?? 0);
-  const isGameOver = !isPlaying && ranking.length;
-  const isGoldCardOpen = isCurrentPlayer && goldCardInfo.title;
+  const isLocatedGoldCardCell = GOLD_CARD_LOCATIONS.includes(
+    currentLocation ?? 0
+  );
+  const isGameOver = !isPlaying && !!ranking.length;
+  const isGoldCardOpen =
+    isCurrentPlayer && isLocatedGoldCardCell && goldCardInfo.title;
 
   useEffect(() => {
     if (lastMessage) {

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -59,11 +59,6 @@ export default function useGameReducer() {
               ...prev.game,
               currentPlayerId: payload.nextPlayerId,
               isMoveFinished: false,
-              goldCardInfo: {
-                cardType: '',
-                title: '',
-                description: '',
-              },
             },
           };
         }
@@ -206,6 +201,11 @@ export default function useGameReducer() {
               ...prev.game,
               timer: payload.timer,
               eventList: [...payload.events],
+              goldCardInfo: {
+                cardType: '',
+                title: '',
+                description: '',
+              },
             },
           };
         }

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -59,6 +59,11 @@ export default function useGameReducer() {
               ...prev.game,
               currentPlayerId: payload.nextPlayerId,
               isMoveFinished: false,
+              goldCardInfo: {
+                cardType: '',
+                title: '',
+                description: '',
+              },
             },
           };
         }
@@ -201,11 +206,6 @@ export default function useGameReducer() {
               ...prev.game,
               timer: payload.timer,
               eventList: [...payload.events],
-              goldCardInfo: {
-                cardType: '',
-                title: '',
-                description: '',
-              },
             },
           };
         }

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -59,6 +59,11 @@ export default function useGameReducer() {
               ...prev.game,
               currentPlayerId: payload.nextPlayerId,
               isMoveFinished: false,
+              goldCardInfo: {
+                cardType: '',
+                title: '',
+                description: '',
+              },
             },
           };
         }
@@ -134,14 +139,6 @@ export default function useGameReducer() {
                 userStatusBoard: payload.userStatusBoard,
               };
             }),
-            game: {
-              ...prev.game,
-              goldCardInfo: {
-                title: '',
-                cardType: '',
-                description: '',
-              },
-            },
           };
         }
 
@@ -197,14 +194,6 @@ export default function useGameReducer() {
                 price: newStock.price,
               };
             }),
-            game: {
-              ...prev.game,
-              goldCardInfo: {
-                title: '',
-                cardType: '',
-                description: '',
-              },
-            },
           };
         }
 
@@ -304,11 +293,6 @@ export default function useGameReducer() {
               ...prev.game,
               teleportPlayerId: payload.playerId,
               teleportLocation: payload.location,
-              goldCardInfo: {
-                title: '',
-                cardType: '',
-                description: '',
-              },
             },
           };
         }


### PR DESCRIPTION
## 📌 이슈번호
- #38 

## 🔑 Key changes
- 황금 카드 랜더링 버그 수정
- 게임 페이지 게임 시작 전 화면 하단 00 랜더링 버그 수정

## 👋 To reviewers
- 황금 카드 랜더링 버그 수정했습니다
  - 황금 카드 모달이 본인 차례에 정상적으로 랜더링 되는 것 확인했습니다
  - 황금 카드 모달이 다른 사람 차례에 랜더링 되지 않는 것 확인했습니다
  - `endTurn` 메세지가 올 경우, 황금 카드 모달에서 상호작용 할 경우 황금 카드 상태를 초기화 시킵니다
    - `endTurn` 메세지에서 초기화 -> 모두에게 적용시키기 위함
    - 황금 카드 모달에서 상호작용시 초기화 -> 황금 카드 칸에 도착한 플레이어가 상호작용 후 황금 카드 모달을 언마운트 시키기 위함
- 게임 페이지 게임 시작 전 화면 하단에 `00`이 랜더링 되던 버그 수정했습니다
  - 게임 종료 모달이 랜더링 되는 조건에 해당하는`isGameOver` 문제였습니다 (`GamePage`컴포넌트 내)
  - `ranking.length`로 판단하다보니, 게임이 끝나기 전 `length`가 0이기 때문에 0이 랜더링 됩니다
    - `0`은 자바스크립트에서 `falsy`한 값이지만, 리액트에서는 있는 그대로 랜더링 됩니다
    - `!!ranking.length`로 수정 후 `false`를 반환하게 하여 해결했습니다
  - 게임 시작 전에만 랜더링 됐던 이유는 `!isPlaying` 조건에 걸리기 떄문입니다
