### PR TITLE
[FE] 감옥칸 버그 및 감정표현 관련 오류 수정

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -9,11 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
-        "@types/lodash.debounce": "^4.0.9",
         "axios": "^1.5.1",
         "jotai": "^2.4.3",
         "jotai-devtools": "^0.7.0",
-        "lodash.debounce": "^4.0.8",
         "react": "^18.2.0",
         "react-confetti": "^6.1.0",
         "react-custom-roulette": "^1.4.1",
@@ -2021,14 +2019,6 @@
       "version": "4.14.200",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
       "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
-    },
-    "node_modules/@types/lodash.debounce": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
-      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.8.6",
@@ -4437,11 +4427,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
       "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
-    },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/fe/package.json
+++ b/fe/package.json
@@ -11,11 +11,9 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
-    "@types/lodash.debounce": "^4.0.9",
     "axios": "^1.5.1",
     "jotai": "^2.4.3",
     "jotai-devtools": "^0.7.0",
-    "lodash.debounce": "^4.0.8",
     "react": "^18.2.0",
     "react-confetti": "^6.1.0",
     "react-custom-roulette": "^1.4.1",

--- a/fe/src/components/GameBoard/Dice.tsx
+++ b/fe/src/components/GameBoard/Dice.tsx
@@ -46,7 +46,7 @@ export default function Dice({ sendCellMessage }: DiceProps) {
     );
     setIsRolling(false);
 
-    if (targetPlayer && targetPlayer.gameBoard.hasEscaped) {
+    if (targetPlayer?.gameBoard.hasEscaped) {
       await moveToken({
         diceCount: totalDiceValue,
         playerGameBoardData: targetPlayer.gameBoard,

--- a/fe/src/components/GameBoard/Dice.tsx
+++ b/fe/src/components/GameBoard/Dice.tsx
@@ -46,16 +46,12 @@ export default function Dice({ sendCellMessage }: DiceProps) {
     );
     setIsRolling(false);
 
-    if (!targetPlayer) return;
-    if (!targetPlayer.gameBoard.hasEscaped) {
-      sendCellMessage(playerId);
-      return;
+    if (targetPlayer && targetPlayer.gameBoard.hasEscaped) {
+      await moveToken({
+        diceCount: totalDiceValue,
+        playerGameBoardData: targetPlayer.gameBoard,
+      });
     }
-
-    await moveToken({
-      diceCount: totalDiceValue,
-      playerGameBoardData: targetPlayer.gameBoard,
-    });
 
     if (isMyTurn) {
       sendCellMessage(playerId);

--- a/fe/src/components/GameBoard/EmotePanel.tsx
+++ b/fe/src/components/GameBoard/EmotePanel.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@components/icon/Icon';
 import useGetSocketUrl from '@hooks/useGetSocketUrl';
 import { usePlayerIdValue } from '@store/index';
 import { EmoteNameType } from '@store/reducer/type';
-import debounce from 'lodash.debounce';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import useWebSocket from 'react-use-websocket';
 import { styled } from 'styled-components';
@@ -19,22 +19,23 @@ export default function EmotePanel({ isActive }: EmotePanelProps) {
   const { sendJsonMessage } = useWebSocket(socketUrl, {
     share: true,
   });
+  const [canSendEmote, setCanSendEmote] = useState(true);
 
   const sendEmote = (name: EmoteNameType) => {
-    const message = {
-      gameId,
-      playerId,
-      name,
-      type: 'emoticon',
-    };
-    sendJsonMessage(message);
+    if (canSendEmote) {
+      const message = {
+        gameId,
+        playerId,
+        name,
+        type: 'emoticon',
+      };
+      sendJsonMessage(message);
+      setCanSendEmote(false);
+      setTimeout(() => {
+        setCanSendEmote(true);
+      }, EMOTE_DEBOUNCE_DELAY);
+    }
   };
-
-  const debounceSendEmote = debounce(
-    (name: EmoteNameType) => sendEmote(name),
-    EMOTE_DEBOUNCE_DELAY,
-    { leading: true, trailing: false }
-  );
 
   return (
     <Panel $isActive={isActive}>
@@ -43,7 +44,7 @@ export default function EmotePanel({ isActive }: EmotePanelProps) {
           name={emote}
           key={emote}
           size="4rem"
-          onClick={() => debounceSendEmote(emote)}
+          onClick={() => sendEmote(emote)}
         />
       ))}
     </Panel>

--- a/fe/src/components/GameBoard/EmotePanel.tsx
+++ b/fe/src/components/GameBoard/EmotePanel.tsx
@@ -21,7 +21,7 @@ export default function EmotePanel({ isActive }: EmotePanelProps) {
   });
   const [canSendEmote, setCanSendEmote] = useState(true);
 
-  const sendEmote = (name: EmoteNameType) => {
+  const debounceSendEmote = (name: EmoteNameType) => {
     if (canSendEmote) {
       const message = {
         gameId,
@@ -44,7 +44,7 @@ export default function EmotePanel({ isActive }: EmotePanelProps) {
           name={emote}
           key={emote}
           size="4rem"
-          onClick={() => sendEmote(emote)}
+          onClick={() => debounceSendEmote(emote)}
         />
       ))}
     </Panel>

--- a/fe/src/components/GameBoard/constants.ts
+++ b/fe/src/components/GameBoard/constants.ts
@@ -76,7 +76,7 @@ export const DIRECTIONS = {
 };
 
 export const DICE_MOVE_DELAY = 200;
-export const EMOTE_DEBOUNCE_DELAY = 1000;
+export const EMOTE_DEBOUNCE_DELAY = 2000;
 
 export const changeDirection = (direction: DirectionType) => {
   switch (direction) {

--- a/fe/src/components/Player/PlayerInfo.tsx
+++ b/fe/src/components/Player/PlayerInfo.tsx
@@ -6,6 +6,7 @@ import { addCommasToNumber } from '@utils/index';
 import { useEffect } from 'react';
 import { styled } from 'styled-components';
 import EmoteBubble from './EmoteBubble';
+import { EMOTE_DISPLAY_TIME } from './constants';
 
 type PlayerInfoProps = {
   player: PlayerType;
@@ -24,7 +25,7 @@ export default function PlayerInfo({ player }: PlayerInfoProps) {
     if (!isEmoteActive || !emoteName) return;
     setTimeout(() => {
       resetPlayerEmote(playerId);
-    }, 2000);
+    }, EMOTE_DISPLAY_TIME);
   }, [isEmoteActive, emoteName, playerId, resetPlayerEmote]);
 
   return (

--- a/fe/src/components/Player/constants.ts
+++ b/fe/src/components/Player/constants.ts
@@ -1,1 +1,2 @@
 export const SCROLL_ONCE = 60;
+export const EMOTE_DISPLAY_TIME = 2000;


### PR DESCRIPTION
## 📌 이슈번호
- #43 

## 🔑 Key changes
- 감옥칸 버그 수정
  - 감옥칸에서 현재 플레이어 외에 다른 플레이어들도 cell 메세지를 보내고 있었던 버그를 해결했습니다.
  - 서버로부터 dice, prisonDice 타입의 메세지가 오면 `Dice` 컴포넌트 내에서 `rollDone` 함수가 실행되는데, 이때 내부에서 `targetPlayer`의 `hasEscaped` 상태가 `false`(감옥에서 탈출하지 못한 상태)이면 `moveToken` 실행을 막도록  early return을 하면서 `sendCellMessage`를 호출하고 있었습니다.
  
    이때 `isMyTurn` 조건을 걸지 않아서 `currentPlayer`외 다른 플레이어들도 cell 메세지를 보내고 있었던 거였습니다.
- 감정표현 디바운스 오류 해결
  - 확인해보니 `leading` 옵션이 `true`로 설정돼있는 경우 제대로 디바운스가 걸리지 않고 있었습니다. (껐을때는 정상적으로 작동)
  - 디버깅해보니 `leading`이 `true`일 때 sendEmote 내부에서 `sendJsonMessage` 함수를 호출하지 않고 단순히 `console.log()`실행만 하면 또 정상적으로 디바운스가 걸렸습니다(?)
  - `sendJsonMessage`, `lodash.debounce` 모두 라이브러리에서 제공되는 함수로 내부를 수정할 수 없었기 때문에 lodash에서 제공하는 debounce 함수 사용을 포기하고 직접 비슷한 동작을 구현해서 해결했습니다. 이 과정에서 `EmotePanel` 컴포넌트 내부에 `canSendEmote`라는 state가 추가되었습니다.
  - 감정표현 말풍선 표시 시간과 디바운스 지연 시간을 동일하게 2초로 변경하였습니다. 이제 플레이어가 한 감정표현을 하면 2초간은 다른 감정표현을 할 수 없습니다.

- lodash.debounce 패키지 제거
  - 불필요해진 패키지는 제거하였습니다.

## 👋 To reviewers
- 플레이어가 두 명인 환경에서의 테스트는 우선 완료한 상태입니다.
