### PR TITLE
[BE] 보유 주식가치 계산 수정

### DIFF
--- a/be/src/main/java/codesquad/gaemimarble/game/player/entity/Player.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/player/entity/Player.java
@@ -71,8 +71,12 @@ public class Player {
 	}
 
 	public void updateStockAsset(String stockName, int currentPrice) {
-		stockAsset = myStocks.get(stockName) * currentPrice;
+		stockAsset += myStocks.get(stockName) * currentPrice;
 		totalAsset = cashAsset + stockAsset;
+	}
+
+	public void initStockAsset() {
+		stockAsset = 0;
 	}
 
 	public void escapePrison(int diceResult) {

--- a/be/src/main/java/codesquad/gaemimarble/game/player/service/PlayerService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/player/service/PlayerService.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import codesquad.gaemimarble.exception.PlayTimeException;
-import codesquad.gaemimarble.game.currentPlayer.entity.CurrentPlayer;
 import codesquad.gaemimarble.game.dto.GameMapper;
 import codesquad.gaemimarble.game.dto.request.GameReadyRequest;
 import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
@@ -128,6 +127,7 @@ public class PlayerService {
 
 	public void updatePlayersAsset(Long gameId) {
 		for (Player player : playerRepository.getAllPlayer(gameId)) {
+			player.initStockAsset();
 			List<Stock> stockList = stockService.getMatchingStocks(gameId, player.getMyStocks().keySet());
 			for (Stock stock : stockList) {
 				player.updateStockAsset(stock.getName(), stock.getCurrentPrice());


### PR DESCRIPTION
## 📌 이슈번호
- #45 

## 🔑 Key changes
- 개인 주식 자산 초기화 후 보유한 주식과 가격을 곱해 자산에 추가하는 로직

