### PR TITLE
[FE] 순간이동 Cell 클릭 버그 해결

### DIFF
--- a/fe/src/components/GameBoard/Cell.tsx
+++ b/fe/src/components/GameBoard/Cell.tsx
@@ -96,6 +96,7 @@ const FrontFace = styled.div<{
   transform: rotateY(0deg) translateZ(1rem)
     ${({ $lineNum }) =>
       $lineNum === 1 || $lineNum === 3 ? 'rotateZ(90deg)' : ''};
+  cursor: ${({ $status }) => ($status === 'teleport' ? 'pointer' : 'default')};
 `;
 
 const Header = styled.div`

--- a/fe/src/components/GameBoard/CenterArea.tsx
+++ b/fe/src/components/GameBoard/CenterArea.tsx
@@ -178,7 +178,9 @@ export default function CenterArea({
       {eventTime && (
         <Roulette sendStatusBoardMessage={sendStatusBoardMessage} />
       )}
-      {!eventTime && <Dice sendCellMessage={sendCellMessage} />}
+      {!eventTime && !teleportStart && (
+        <Dice sendCellMessage={sendCellMessage} />
+      )}
       {defaultStart && (
         <Button onClick={handleThrowDice} disabled={isMoveFinished}>
           굴리기
@@ -204,7 +206,8 @@ export default function CenterArea({
       )}
       {teleportStart && (
         <>
-          <div>이동할 칸을 선택한 후 이동하기 버튼을 눌러주세요.</div>
+          <span>이동할 칸을 선택한 후</span>
+          <span>이동하기 버튼을 눌러주세요.</span>
           <Button onClick={handleTeleport}>이동하기</Button>
         </>
       )}
@@ -216,9 +219,8 @@ export default function CenterArea({
 }
 
 const Center = styled.div`
-  z-index: 70;
-  width: 30rem;
-  height: 30rem;
+  width: 20rem;
+  height: 20rem;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/fe/src/components/GameBoard/Roulette.tsx
+++ b/fe/src/components/GameBoard/Roulette.tsx
@@ -106,7 +106,7 @@ const Container = styled.div`
 const Wrapper = styled.div`
   position: fixed;
   padding: 0.5rem 1rem;
-  top: -2rem;
+  top: -6rem;
   display: flex;
   justify-content: center;
   background-color: black;


### PR DESCRIPTION
- CenterArea 컴포넌트 크기를 줄여서 해결

## 📌 이슈번호
- #52 

## 🔑 Key changes
![스크린샷 2023-12-08 오후 2 25 44](https://github.com/gaemi-marble/gaemi-marble/assets/76121068/d6079d62-b1ca-423c-92ee-2672296dab19)

- `CenterArea` 컴포넌트 크기 수정
- 불필요한 z-index 삭제
- 텔레포트 시 마우스 커서 포인트로 변경

## 👋 To reviewers
- - 왜 특정영역만 클릭이 잘 안되는 걸까 찾아봤는데 단순히 CenterArea가 차지하는 영역만큼 GameBoard가 가려지고 있어서 클릭이 안되는 거였네요 😅 간단하게 CenterArea 크기를 줄여서 해결하였습니다.