### PR TITLE
[FE] 발견된 순간이동 버그 추가 수정

### DIFF
--- a/fe/src/components/GameBoard/Cell.tsx
+++ b/fe/src/components/GameBoard/Cell.tsx
@@ -96,6 +96,7 @@ const FrontFace = styled.div<{
   transform: rotateY(0deg) translateZ(1rem)
     ${({ $lineNum }) =>
       $lineNum === 1 || $lineNum === 3 ? 'rotateZ(90deg)' : ''};
+  cursor: ${({ $status }) => ($status === 'teleport' ? 'pointer' : 'default')};
 `;
 
 const Header = styled.div`

--- a/fe/src/components/GameBoard/CenterArea.tsx
+++ b/fe/src/components/GameBoard/CenterArea.tsx
@@ -87,7 +87,7 @@ export default function CenterArea({
   );
 
   useEffect(() => {
-    if (!teleportLocation) return;
+    if (!teleportLocation || !targetLocation) return;
     const targetPlayer = players.find(
       (player) => player.playerId === teleportPlayerId
     );
@@ -104,6 +104,7 @@ export default function CenterArea({
   }, [
     players,
     playerId,
+    targetLocation,
     teleportPlayerId,
     teleportLocation,
     teleportToken,

--- a/fe/src/components/GameBoard/CenterArea.tsx
+++ b/fe/src/components/GameBoard/CenterArea.tsx
@@ -87,7 +87,7 @@ export default function CenterArea({
   );
 
   useEffect(() => {
-    if (!teleportLocation || !targetLocation) return;
+    if (!teleportLocation) return;
     const targetPlayer = players.find(
       (player) => player.playerId === teleportPlayerId
     );
@@ -104,7 +104,6 @@ export default function CenterArea({
   }, [
     players,
     playerId,
-    targetLocation,
     teleportPlayerId,
     teleportLocation,
     teleportToken,

--- a/fe/src/components/GameBoard/CenterArea.tsx
+++ b/fe/src/components/GameBoard/CenterArea.tsx
@@ -178,7 +178,9 @@ export default function CenterArea({
       {eventTime && (
         <Roulette sendStatusBoardMessage={sendStatusBoardMessage} />
       )}
-      {!eventTime && <Dice sendCellMessage={sendCellMessage} />}
+      {!eventTime && !teleportStart && (
+        <Dice sendCellMessage={sendCellMessage} />
+      )}
       {defaultStart && (
         <Button onClick={handleThrowDice} disabled={isMoveFinished}>
           굴리기
@@ -204,7 +206,8 @@ export default function CenterArea({
       )}
       {teleportStart && (
         <>
-          <div>이동할 칸을 선택한 후 이동하기 버튼을 눌러주세요.</div>
+          <span>이동할 칸을 선택한 후</span>
+          <span>이동하기 버튼을 눌러주세요.</span>
           <Button onClick={handleTeleport}>이동하기</Button>
         </>
       )}
@@ -216,9 +219,8 @@ export default function CenterArea({
 }
 
 const Center = styled.div`
-  z-index: 70;
-  width: 30rem;
-  height: 30rem;
+  width: 20rem;
+  height: 20rem;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/fe/src/components/GameBoard/Roulette.tsx
+++ b/fe/src/components/GameBoard/Roulette.tsx
@@ -106,7 +106,7 @@ const Container = styled.div`
 const Wrapper = styled.div`
   position: fixed;
   padding: 0.5rem 1rem;
-  top: -2rem;
+  top: -6rem;
   display: flex;
   justify-content: center;
   background-color: black;

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -57,6 +57,7 @@ export default function useGameReducer() {
             ...prev,
             game: {
               ...prev.game,
+              dice: [0, 0],
               currentPlayerId: payload.nextPlayerId,
               isMoveFinished: false,
               goldCardInfo: {


### PR DESCRIPTION
## 📌 이슈번호
- #52 

## 🔑 Key changes
- dice1, 2의 이전 값이 남아있어서 순간이동시 버그가 발생하는 것 같아 endTurn시 초기화 하도록 변경하였습니다.

## 👋 To reviewers
- 
