### PR TITLE
[FE] 플레이어 카드 요소 배치 수정 및 감정 표현 말풍선 짤림 버그 수정

### DIFF
--- a/fe/src/components/Player/EmoteBubble.tsx
+++ b/fe/src/components/Player/EmoteBubble.tsx
@@ -28,6 +28,7 @@ const Bubble = styled.div<{ $position: BubblePositionType }>`
   align-items: center;
   border-radius: ${({ theme }) => theme.radius.large};
   background-color: ${({ theme }) => theme.color.accentBeige};
+  z-index: 100;
 
   &:after {
     content: '';

--- a/fe/src/components/Player/PlayerCard.tsx
+++ b/fe/src/components/Player/PlayerCard.tsx
@@ -66,9 +66,11 @@ export default function PlayerCard({ player }: PlayerCardProps) {
             </ButtonWrapper>
           )}
           {isMyButton && eventTime && beforeRouletteSpin && (
-            <StockSellButton onClick={toggleStockSellModal}>
-              매도하기
-            </StockSellButton>
+            <ButtonWrapper>
+              <StockSellButton onClick={toggleStockSellModal}>
+                매도하기
+              </StockSellButton>
+            </ButtonWrapper>
           )}
         </CardWrapper>
       )}
@@ -125,4 +127,19 @@ const StockSellButton = styled.button`
   height: 3rem;
   border: 1px solid;
   border-radius: ${({ theme: { radius } }) => radius.small};
+  box-shadow: 0 0.5rem 0 #9d9d9d;
+  color: ${({ theme: { color } }) => color.neutralText};
+  background-color: ${({ theme: { color } }) => color.neutralBackground};
+
+  &:hover {
+    box-shadow: none;
+    transform: translateY(0.5rem);
+    transition: transform 0.1s box-shadow 0.1s;
+  }
+
+  &:active {
+    height: 2.5rem;
+    box-shadow: 0 -0.5rem 0 #9d9d9d;
+    transform: translateY(1rem);
+  }
 `;

--- a/fe/src/components/Player/PlayerCard.tsx
+++ b/fe/src/components/Player/PlayerCard.tsx
@@ -1,6 +1,4 @@
 import StockSellModal from '@components/Modal/StockSellModal/StockSellModal';
-import { Icon } from '@components/icon/Icon';
-import useClickScrollButton from '@hooks/useClickScrollButton';
 import useGetSocketUrl from '@hooks/useGetSocketUrl';
 import { usePlayerIdValue } from '@store/index';
 import { useGameInfoValue } from '@store/reducer';
@@ -10,21 +8,18 @@ import { useParams } from 'react-router';
 import useWebSocket from 'react-use-websocket';
 import { styled } from 'styled-components';
 import PlayerInfo from './PlayerInfo';
-import PlayerStock from './PlayerStock';
-import { SCROLL_ONCE } from './constants';
+import PlayerStockList from './PlayerStockList';
+import { BOTTOM_PLAYERS } from './constants';
 
 type PlayerCardProps = {
   player: PlayerType;
 };
 
 export default function PlayerCard({ player }: PlayerCardProps) {
-  const { ref, handleClickScroll } = useClickScrollButton<HTMLUListElement>({
-    width: SCROLL_ONCE,
-  });
   const { gameId } = useParams();
   const myId = usePlayerIdValue();
   const { currentPlayerId, eventResult, isPlaying } = useGameInfoValue();
-  const { isReady, playerId, userStatusBoard } = player;
+  const { isReady, playerId, userStatusBoard, order } = player;
   const [isStockSellModalOpen, setIsStockSellModalOpen] = useState(false);
   const socketUrl = useGetSocketUrl();
   const { sendJsonMessage } = useWebSocket(socketUrl, {
@@ -49,27 +44,15 @@ export default function PlayerCard({ player }: PlayerCardProps) {
     setIsStockSellModalOpen((prev) => !prev);
   };
 
+  const isBottomCard = BOTTOM_PLAYERS.includes(order ?? 0);
+
   return (
     <>
       {playerId && (
-        <CardWrapper>
+        <CardWrapper $isBottomCard={isBottomCard}>
           <PlayerInfo player={player} />
           {!!userStatusBoard.stockList.length && (
-            <>
-              <StockWrapper>
-                <ArrowButton onClick={() => handleClickScroll()}>
-                  <Icon name="arrowLeft" color="accentText" />
-                </ArrowButton>
-                <PlayerStockList ref={ref}>
-                  {userStatusBoard.stockList.map((stock) => (
-                    <PlayerStock key={stock.name} stockInfo={stock} />
-                  ))}
-                </PlayerStockList>
-                <ArrowButton onClick={() => handleClickScroll(true)}>
-                  <Icon name="arrowRight" color="accentText" />
-                </ArrowButton>
-              </StockWrapper>
-            </>
+            <PlayerStockList stockList={userStatusBoard.stockList} />
           )}
           {!isPlaying && (
             <ButtonWrapper>
@@ -87,47 +70,23 @@ export default function PlayerCard({ player }: PlayerCardProps) {
               매도하기
             </StockSellButton>
           )}
-          {isStockSellModalOpen && eventTime && beforeRouletteSpin && (
-            <StockSellModal handleClose={toggleStockSellModal} />
-          )}
         </CardWrapper>
+      )}
+      {isStockSellModalOpen && eventTime && beforeRouletteSpin && (
+        <StockSellModal handleClose={toggleStockSellModal} />
       )}
     </>
   );
 }
 
-const CardWrapper = styled.div`
+const CardWrapper = styled.div<{
+  $isBottomCard: boolean;
+}>`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${({ $isBottomCard }) =>
+    $isBottomCard ? 'column-reverse' : 'column'};
   align-items: center;
   gap: 0.5rem;
-`;
-
-const StockWrapper = styled.div`
-  width: 22rem;
-  display: flex;
-  flex-direction: row;
-  gap: 0.5rem;
-  border-radius: ${({ theme: { radius } }) => radius.small};
-  background-color: ${({ theme: { color } }) => color.neutralBackground};
-`;
-
-const PlayerStockList = styled.ul`
-  flex: 1;
-  display: flex;
-  gap: 0.5rem;
-  overflow: scroll;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;
-
-const ArrowButton = styled.button`
-  width: 1rem;
-  height: 3rem;
-  border-radius: ${({ theme: { radius } }) => radius.small};
-  background-color: ${({ theme: { color } }) => color.neutralBackgroundBold};
 `;
 
 const ButtonWrapper = styled.div`

--- a/fe/src/components/Player/PlayerCard.tsx
+++ b/fe/src/components/Player/PlayerCard.tsx
@@ -44,7 +44,7 @@ export default function PlayerCard({ player }: PlayerCardProps) {
     setIsStockSellModalOpen((prev) => !prev);
   };
 
-  const isBottomCard = BOTTOM_PLAYERS.includes(order ?? 0);
+  const isBottomCard = BOTTOM_PLAYERS.includes(order);
 
   return (
     <>

--- a/fe/src/components/Player/PlayerStock.tsx
+++ b/fe/src/components/Player/PlayerStock.tsx
@@ -50,6 +50,10 @@ const StockImgWrapper = styled.li`
   position: relative;
   border-radius: ${({ theme }) => theme.radius.small};
   background-color: ${({ theme }) => theme.color.accentText};
+
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 const StockImg = styled.img`

--- a/fe/src/components/Player/PlayerStockList.tsx
+++ b/fe/src/components/Player/PlayerStockList.tsx
@@ -1,0 +1,61 @@
+import { Icon } from '@components/icon/Icon';
+import useClickScrollButton from '@hooks/useClickScrollButton';
+import { StockType } from '@store/reducer/type';
+import { styled } from 'styled-components';
+import PlayerStock from './PlayerStock';
+import { SCROLL_ONCE } from './constants';
+
+type PlayerStockListProps = {
+  stockList: Pick<StockType, 'name' | 'quantity'>[];
+};
+
+export default function PlayerStockList({ stockList }: PlayerStockListProps) {
+  const { ref, handleClickScroll } = useClickScrollButton<HTMLUListElement>({
+    width: SCROLL_ONCE,
+  });
+
+  return (
+    <>
+      <StockWrapper>
+        <ArrowButton onClick={() => handleClickScroll()}>
+          <Icon name="arrowLeft" color="accentText" />
+        </ArrowButton>
+        <PlayerStocks ref={ref}>
+          {stockList.map((stock) => (
+            <PlayerStock key={stock.name} stockInfo={stock} />
+          ))}
+        </PlayerStocks>
+        <ArrowButton onClick={() => handleClickScroll(true)}>
+          <Icon name="arrowRight" color="accentText" />
+        </ArrowButton>
+      </StockWrapper>
+    </>
+  );
+}
+
+const StockWrapper = styled.div`
+  width: 22rem;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: ${({ theme: { radius } }) => radius.small};
+  background-color: ${({ theme: { color } }) => color.neutralBackground};
+`;
+
+const PlayerStocks = styled.ul`
+  flex: 1;
+  display: flex;
+  gap: 0.5rem;
+  overflow: scroll;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ArrowButton = styled.button`
+  width: 1rem;
+  height: 3rem;
+  border-radius: ${({ theme: { radius } }) => radius.small};
+  background-color: ${({ theme: { color } }) => color.neutralBackgroundBold};
+`;

--- a/fe/src/components/Player/constants.ts
+++ b/fe/src/components/Player/constants.ts
@@ -1,2 +1,4 @@
 export const SCROLL_ONCE = 60;
 export const EMOTE_DISPLAY_TIME = 2000;
+export const TOP_PLAYERS = [1, 2];
+export const BOTTOM_PLAYERS = [3, 4];


### PR DESCRIPTION
## 📌 이슈번호
- #58 

## 🔑 Key changes
- 플레이어 카드 요소 배치 수정

<img width="1415" alt="image" src="https://github.com/gaemi-marble/gaemi-marble/assets/101464713/849bd000-29af-4ec1-a963-0d88441f9087">

</br>
</br>

- 감정 표현 말풍선 짤림 버그 수정
<img width="334" alt="image" src="https://github.com/gaemi-marble/gaemi-marble/assets/101464713/4e03d1eb-e1d7-4e16-a236-38954f14b571">

</br>
</br>

- 매도하기 버튼 디자인 수정

https://github.com/gaemi-marble/gaemi-marble/assets/101464713/a6095913-4a5e-4dbb-aca4-9d244db1fd7d

## 👋 To reviewers
-  플레이어 카드의 위치에 따라 요소 배치를 변경했습니다
   - 아래에 위치한 카드는 주식 리스트와 매도하기 버튼이 카드 위에 위치하도록 했습니다
- 감정 표현 말풍선 짤림 버그 수정했습니다
   - z-index 조정 -> 수치는 임의로 조정했습니다
- 매도하기 버튼 디자인 수정했습니다
   - 준비하기 버튼 참고했습니다