### PR TITLE
[FE] useGameReducer 구조 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Create env file
         run: |

--- a/fe/src/components/GameBoard/GameBoard.tsx
+++ b/fe/src/components/GameBoard/GameBoard.tsx
@@ -35,7 +35,7 @@ export default function GameBoard() {
   const currentPlayer = players.find(
     (player) => player.playerId === currentPlayerId
   );
-  const currentPlayerStatus = currentPlayer?.gameBoard.status ?? 'event';
+  const currentPlayerStatus = currentPlayer!.gameBoard.status;
   const isCaptain =
     players.find((player) => player.playerId === playerId)?.order === 1;
 

--- a/fe/src/store/reducer/type.ts
+++ b/fe/src/store/reducer/type.ts
@@ -6,25 +6,24 @@ export type GameType = {
   stocks: StockType[];
 };
 
-export type GameActionType = {
-  start: StartPayloadType;
-  endTurn: EndTurnPayloadType;
-  dice: DicePayloadType;
-  enter: EnterPayloadType[];
-  ready: ReadyPayloadType;
-  userStatusBoard: UserStatusPayloadType;
-  cell: CellPayloadType;
-  statusBoard: StatusBoardPayloadType;
-  events: EventsPayloadType;
-  eventResult: EventResultPayloadType;
-  goldCard: GoldCardPayloadType;
-  prisonDice: PrisonDicePayloadType;
-  teleport: TeleportPayloadType;
-  gameOver: GameOverPayloadType;
-  currentPlayer: CurrentPlayerPayloadType;
-  locations: LocationsPayloadType[];
-  emoticon: EmoticonPayloadType;
-};
+export type GameActionType =
+  | { type: 'start'; payload: StartPayloadType }
+  | { type: 'endTurn'; payload: EndTurnPayloadType }
+  | { type: 'dice'; payload: DicePayloadType }
+  | { type: 'enter'; payload: EnterPayloadType[] }
+  | { type: 'ready'; payload: ReadyPayloadType }
+  | { type: 'userStatusBoard'; payload: UserStatusPayloadType }
+  | { type: 'cell'; payload: CellPayloadType }
+  | { type: 'statusBoard'; payload: StatusBoardPayloadType }
+  | { type: 'events'; payload: EventsPayloadType }
+  | { type: 'eventResult'; payload: EventResultPayloadType }
+  | { type: 'goldCard'; payload: GoldCardPayloadType }
+  | { type: 'prisonDice'; payload: PrisonDicePayloadType }
+  | { type: 'teleport'; payload: TeleportPayloadType }
+  | { type: 'gameOver'; payload: GameOverPayloadType }
+  | { type: 'currentPlayer'; payload: CurrentPlayerPayloadType }
+  | { type: 'locations'; payload: LocationsPayloadType[] }
+  | { type: 'emoticon'; payload: EmoticonPayloadType };
 
 export type GameInfoType = {
   isPlaying: boolean;

--- a/fe/src/store/reducer/type.ts
+++ b/fe/src/store/reducer/type.ts
@@ -150,7 +150,7 @@ export type RouletteEvent = {
   impact: string;
 };
 
-export type PlayerStatusType = 'default' | 'prison' | 'teleport' | 'event';
+export type PlayerStatusType = 'default' | 'prison' | 'teleport';
 
 export type GoldCardPayloadType = {
   cardType: string;

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -19,6 +19,8 @@ import {
   LocationsPayloadType,
   GameOverPayloadType,
   EmoticonPayloadType,
+  GameType,
+  PlayerType,
 } from './type';
 import { gameAtom } from '.';
 
@@ -27,356 +29,78 @@ export default function useGameReducer() {
 
   const [gameInfo, dispatch] = useReducerAtom(
     gameAtom,
-    (
-      prev,
-      action: {
-        type: keyof GameActionType;
-        payload: GameActionType[keyof GameActionType];
-      }
-    ) => {
-      switch (action.type) {
-        case 'start': {
-          const payload = action.payload as StartPayloadType;
+    (prev, action: GameActionType) => {
+      const { type, payload } = action;
 
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              firstPlayerId: payload.playerId,
-              currentPlayerId: payload.playerId,
-              isPlaying: true,
-            },
-          };
+      switch (type) {
+        case 'start': {
+          return handleGameAction(prev, payload);
         }
 
         case 'endTurn': {
-          const payload = action.payload as EndTurnPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              dice: [0, 0],
-              currentPlayerId: payload.nextPlayerId,
-              isMoveFinished: false,
-              goldCardInfo: {
-                cardType: '',
-                title: '',
-                description: '',
-              },
-            },
-          };
+          return handleEndTurnAction(prev, payload);
         }
 
         case 'dice': {
-          const payload = action.payload as DicePayloadType;
-          const { dice1, dice2 } = payload;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              dice: [dice1, dice2],
-            },
-          };
+          return handleDiceAction(prev, payload);
         }
 
         case 'enter': {
-          return {
-            ...prev,
-            players: prev.players.map((player) => {
-              const payload = action.payload as EnterPayloadType[];
-
-              const currentPlayer = payload.find(
-                (currentPlayer) => currentPlayer.order === player.order
-              );
-
-              if (!currentPlayer) {
-                return player;
-              }
-
-              const { playerId, isReady } = currentPlayer;
-
-              return {
-                ...player,
-                playerId: playerId,
-                isReady: isReady,
-              };
-            }),
-          };
+          return handleEnterAction(prev, payload);
         }
 
         case 'ready': {
-          return {
-            ...prev,
-            players: prev.players.map((player) => {
-              const payload = action.payload as ReadyPayloadType;
-
-              if (player.playerId !== payload.playerId) {
-                return player;
-              }
-
-              return {
-                ...player,
-                isReady: payload.isReady,
-              };
-            }),
-          };
+          return handleReadyAction(prev, payload);
         }
 
         case 'userStatusBoard': {
-          return {
-            ...prev,
-            players: prev.players.map((player) => {
-              const payload = action.payload as UserStatusPayloadType;
-
-              if (player.playerId !== payload.playerId) {
-                return player;
-              }
-
-              return {
-                ...player,
-                userStatusBoard: payload.userStatusBoard,
-              };
-            }),
-          };
+          return handleUserStatusBoardAction(prev, payload);
         }
 
         case 'cell': {
-          const payload = action.payload as CellPayloadType;
-          const playerStatus =
-            payload.location === 6
-              ? ('prison' as const)
-              : payload.location === 18
-              ? ('teleport' as const)
-              : ('default' as const);
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              isMoveFinished: true,
-            },
-            players: prev.players.map((player) => {
-              if (player.playerId !== payload.playerId) {
-                return player;
-              }
-
-              return {
-                ...player,
-                location: payload.location,
-                gameBoard: {
-                  ...player.gameBoard,
-                  status: playerStatus,
-                },
-              };
-            }),
-          };
+          return handleCellAction(prev, payload);
         }
 
         case 'statusBoard': {
-          const payload = action.payload as StatusBoardPayloadType;
-
-          return {
-            ...prev,
-            stocks: prev.stocks.map((stock) => {
-              const newStock = payload.stockStatusBoard.find(
-                (resStock) => resStock.name === stock.name
-              );
-
-              if (!newStock) {
-                return stock;
-              }
-
-              return {
-                ...stock,
-                quantity: newStock.quantity,
-                price: newStock.price,
-              };
-            }),
-          };
+          return handleStatusBoardAction(prev, payload);
         }
 
         case 'events': {
-          const payload = action.payload as EventsPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              timer: payload.timer,
-              eventList: [...payload.events],
-            },
-          };
+          return handleEventsAction(prev, payload);
         }
 
         case 'eventResult': {
-          const payload = action.payload as EventResultPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              eventResult: payload.name,
-            },
-          };
+          return handleEventResultAction(prev, payload);
         }
 
         case 'goldCard': {
-          const payload = action.payload as GoldCardPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              goldCardInfo: {
-                cardType: payload.cardType,
-                title: payload.title,
-                description: payload.description,
-              },
-            },
-          };
+          return handleGoldCardAction(prev, payload);
         }
 
         case 'prisonDice': {
-          const payload = action.payload as PrisonDicePayloadType;
-          const { dice1, dice2 } = payload;
-
-          if (payload.hasEscaped) {
-            return {
-              ...prev,
-              game: {
-                ...prev.game,
-                dice: [dice1, dice2],
-              },
-              players: prev.players.map((player) => {
-                if (player.playerId !== payload.playerId) {
-                  return player;
-                }
-                return {
-                  ...player,
-                  gameBoard: {
-                    ...player.gameBoard,
-                    hasEscaped: true,
-                  },
-                };
-              }),
-            };
-          }
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              dice: [dice1, dice2],
-            },
-            players: prev.players.map((player) => {
-              if (player.playerId !== payload.playerId) {
-                return player;
-              }
-              return {
-                ...player,
-                gameBoard: {
-                  ...player.gameBoard,
-                  hasEscaped: false,
-                },
-              };
-            }),
-          };
+          return handlePrisonDiceAction(prev, payload);
         }
 
         case 'teleport': {
-          const payload = action.payload as TeleportPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              teleportPlayerId: payload.playerId,
-              teleportLocation: payload.location,
-            },
-          };
+          return handleTeleportAction(prev, payload);
         }
 
         case 'currentPlayer': {
-          const payload = action.payload as CurrentPlayerPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              currentPlayerId: payload.playerId,
-            },
-          };
+          return handleCurrentPlayerAction(prev, payload);
         }
 
         // Memo: enter 메세지가 오기전에 먼저 실행돼서 작동을 안 합니다.
         // players 상태가 비어있는 초기 상태로 들어가서 이를 해결해야 할 것 같습니다.
         case 'locations': {
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              isPlaying: true,
-            },
-            players: prev.players.map((player) => {
-              const payload = action.payload as LocationsPayloadType[];
-
-              const currentPlayer = payload.find(
-                (currentPlayer) => currentPlayer.playerId === player.playerId
-              );
-
-              if (!currentPlayer) {
-                return player;
-              }
-
-              const { location } = currentPlayer;
-
-              teleportToken({
-                location,
-                playerData: player,
-              });
-
-              return {
-                ...player,
-                location: location,
-              };
-            }),
-          };
+          return handleLocationsAction(prev, payload, teleportToken);
         }
 
         case 'gameOver': {
-          const payload = action.payload as GameOverPayloadType;
-
-          return {
-            ...prev,
-            game: {
-              ...prev.game,
-              isPlaying: false,
-              ranking: [...payload.ranking],
-            },
-          };
+          return handleGameOverAction(prev, payload);
         }
 
         case 'emoticon': {
-          const payload = action.payload as EmoticonPayloadType;
-          const { playerId, name } = payload;
-
-          return {
-            ...prev,
-            players: prev.players.map((player) => {
-              if (player.playerId !== playerId) {
-                return player;
-              }
-
-              return {
-                ...player,
-                emote: {
-                  name: name,
-                  isActive: true,
-                },
-              };
-            }),
-          };
+          return handleEmoticonAction(prev, payload);
         }
 
         default: {
@@ -387,4 +111,342 @@ export default function useGameReducer() {
   );
 
   return { gameInfo, dispatch };
+}
+
+function handleGameAction(prev: GameType, payload: StartPayloadType) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      firstPlayerId: payload.playerId,
+      currentPlayerId: payload.playerId,
+      isPlaying: true,
+    },
+  };
+}
+
+function handleEndTurnAction(prev: GameType, payload: EndTurnPayloadType) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      dice: [0, 0],
+      currentPlayerId: payload.nextPlayerId,
+      isMoveFinished: false,
+      goldCardInfo: {
+        cardType: '',
+        title: '',
+        description: '',
+      },
+    },
+  };
+}
+
+function handleDiceAction(prev: GameType, payload: DicePayloadType) {
+  const { dice1, dice2 } = payload;
+
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      dice: [dice1, dice2],
+    },
+  };
+}
+
+function handleEnterAction(prev: GameType, payload: EnterPayloadType[]) {
+  return {
+    ...prev,
+    players: prev.players.map((player) => {
+      const currentPlayer = payload.find(
+        (currentPlayer) => currentPlayer.order === player.order
+      );
+
+      if (!currentPlayer) {
+        return player;
+      }
+
+      const { playerId, isReady } = currentPlayer;
+
+      return {
+        ...player,
+        playerId: playerId,
+        isReady: isReady,
+      };
+    }),
+  };
+}
+
+function handleReadyAction(prev: GameType, payload: ReadyPayloadType) {
+  return {
+    ...prev,
+    players: prev.players.map((player) => {
+      if (player.playerId !== payload.playerId) {
+        return player;
+      }
+
+      return {
+        ...player,
+        isReady: payload.isReady,
+      };
+    }),
+  };
+}
+
+function handleUserStatusBoardAction(
+  prev: GameType,
+  payload: UserStatusPayloadType
+) {
+  return {
+    ...prev,
+    players: prev.players.map((player) => {
+      if (player.playerId !== payload.playerId) {
+        return player;
+      }
+
+      return {
+        ...player,
+        userStatusBoard: payload.userStatusBoard,
+      };
+    }),
+  };
+}
+
+function handleCellAction(prev: GameType, payload: CellPayloadType) {
+  const playerStatus =
+    payload.location === 6
+      ? ('prison' as const)
+      : payload.location === 18
+      ? ('teleport' as const)
+      : ('default' as const);
+
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      isMoveFinished: true,
+    },
+    players: prev.players.map((player) => {
+      if (player.playerId !== payload.playerId) {
+        return player;
+      }
+
+      return {
+        ...player,
+        location: payload.location,
+        gameBoard: {
+          ...player.gameBoard,
+          status: playerStatus,
+        },
+      };
+    }),
+  };
+}
+
+function handleStatusBoardAction(
+  prev: GameType,
+  payload: StatusBoardPayloadType
+) {
+  return {
+    ...prev,
+    stocks: prev.stocks.map((stock) => {
+      const newStock = payload.stockStatusBoard.find(
+        (resStock) => resStock.name === stock.name
+      );
+
+      if (!newStock) {
+        return stock;
+      }
+
+      return {
+        ...stock,
+        quantity: newStock.quantity,
+        price: newStock.price,
+      };
+    }),
+  };
+}
+
+function handleEventsAction(prev: GameType, payload: EventsPayloadType) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      timer: payload.timer,
+      eventList: [...payload.events],
+    },
+  };
+}
+
+function handleEventResultAction(
+  prev: GameType,
+  payload: EventResultPayloadType
+) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      eventResult: payload.name,
+    },
+  };
+}
+
+function handleGoldCardAction(prev: GameType, payload: GoldCardPayloadType) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      goldCardInfo: {
+        cardType: payload.cardType,
+        title: payload.title,
+        description: payload.description,
+      },
+    },
+  };
+}
+
+function handlePrisonDiceAction(
+  prev: GameType,
+  payload: PrisonDicePayloadType
+) {
+  const { dice1, dice2 } = payload;
+
+  if (payload.hasEscaped) {
+    return {
+      ...prev,
+      game: {
+        ...prev.game,
+        dice: [dice1, dice2],
+      },
+      players: prev.players.map((player) => {
+        if (player.playerId !== payload.playerId) {
+          return player;
+        }
+        return {
+          ...player,
+          gameBoard: {
+            ...player.gameBoard,
+            hasEscaped: true,
+          },
+        };
+      }),
+    };
+  }
+
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      dice: [dice1, dice2],
+    },
+    players: prev.players.map((player) => {
+      if (player.playerId !== payload.playerId) {
+        return player;
+      }
+      return {
+        ...player,
+        gameBoard: {
+          ...player.gameBoard,
+          hasEscaped: false,
+        },
+      };
+    }),
+  };
+}
+
+function handleTeleportAction(prev: GameType, payload: TeleportPayloadType) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      teleportPlayerId: payload.playerId,
+      teleportLocation: payload.location,
+    },
+  };
+}
+
+function handleCurrentPlayerAction(
+  prev: GameType,
+  payload: CurrentPlayerPayloadType
+) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      currentPlayerId: payload.playerId,
+    },
+  };
+}
+
+function handleLocationsAction(
+  prev: GameType,
+  payload: LocationsPayloadType[],
+  teleportToken: ({
+    location,
+    playerData,
+  }: {
+    location: number;
+    playerData: PlayerType;
+  }) => void
+) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      isPlaying: true,
+    },
+    players: prev.players.map((player) => {
+      const currentPlayer = payload.find(
+        (currentPlayer) => currentPlayer.playerId === player.playerId
+      );
+
+      if (!currentPlayer) {
+        return player;
+      }
+
+      const { location } = currentPlayer;
+
+      teleportToken({
+        location,
+        playerData: player,
+      });
+
+      return {
+        ...player,
+        location: location,
+      };
+    }),
+  };
+}
+
+function handleGameOverAction(prev: GameType, payload: GameOverPayloadType) {
+  return {
+    ...prev,
+    game: {
+      ...prev.game,
+      isPlaying: false,
+      ranking: [...payload.ranking],
+    },
+  };
+}
+
+function handleEmoticonAction(prev: GameType, payload: EmoticonPayloadType) {
+  const { playerId, name } = payload;
+
+  return {
+    ...prev,
+    players: prev.players.map((player) => {
+      if (player.playerId !== playerId) {
+        return player;
+      }
+
+      return {
+        ...player,
+        emote: {
+          name: name,
+          isActive: true,
+        },
+      };
+    }),
+  };
 }

--- a/fe/src/store/reducer/useGameReducer.tsx
+++ b/fe/src/store/reducer/useGameReducer.tsx
@@ -8,7 +8,6 @@ import {
   EventResultPayloadType,
   EventsPayloadType,
   GameActionType,
-  PlayerStatusType,
   GoldCardPayloadType,
   PrisonDicePayloadType,
   ReadyPayloadType,
@@ -147,10 +146,10 @@ export default function useGameReducer() {
           const payload = action.payload as CellPayloadType;
           const playerStatus =
             payload.location === 6
-              ? 'prison'
+              ? ('prison' as const)
               : payload.location === 18
-              ? 'teleport'
-              : 'default';
+              ? ('teleport' as const)
+              : ('default' as const);
 
           return {
             ...prev,
@@ -168,7 +167,7 @@ export default function useGameReducer() {
                 location: payload.location,
                 gameBoard: {
                   ...player.gameBoard,
-                  status: playerStatus as PlayerStatusType,
+                  status: playerStatus,
                 },
               };
             }),


### PR DESCRIPTION
## 📌 이슈번호
- #60 

## 🔑 Key changes
- 플레이어 상태 중 불필요한 상태(event) 제거
- useGameReducer 구조 개선
- Github Actions Node js 버전 업그레이드

## 👋 To reviewers
- 플레이어 상태 (`type PlayerStatusType = 'default' | 'prison' | 'teleport' | 'event'`) 중 
  쓰이지 않는 `'event'`타입을 제거하여
  불필요한 type assertion 과정을 생략하였습니다
- useGameReducer 구조 개선
  - `GameActionType`을 유니온 타입으로 변경하여 
  `action`의 `type`이 결정되면 `payload`의 타입을 컴파일 과정에서 추론할 수 있도록 변경하였습니다
  - `switch 문` 내 `case 문`의 내부 로직을 함수로 분리하여 코드의 가독성을 향상시켰습니다
- Github Actions가 더 이상 Node js 18버전(v3)을 지원하지 않아 20버전(v4)으로 업그레이드 시켰습니다
  - 다만, 버킷을 내려서 CI/CD가 동작하지 않는 듯 합니다!

1. Node js 버전 에러
- <img width="1033" alt="image" src="https://github.com/gaemi-marble/gaemi-marble/assets/101464713/978302fe-63ab-4cfd-ba71-3d5347965165">
2. 버킷 에러
- <img width="463" alt="image" src="https://github.com/gaemi-marble/gaemi-marble/assets/101464713/fe3da2eb-453c-4697-9cc9-a183b6e0f827">

